### PR TITLE
Bootable From .iso

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -3,7 +3,10 @@ OBJECTS=kernelcore.o main.o console.o memory.o keyboard.o clock.o interrupt.o pi
 KERNEL_CCFLAGS=-Wall -c -ffreestanding -m32 -march=i386
 KERNEL_LDFLAGS=-m elf_i386
 
-all: basekernel.img
+all: basekernel.iso
+
+basekernel.iso: basekernel.img
+	mkisofs -J -R -o basekernel.iso -b basekernel.img basekernel.img
 
 basekernel.img: bootblock kernel
 	cat bootblock kernel > basekernel.img


### PR DESCRIPTION
Updated the Makefile to create a .iso image file with a bootable floppy disk .img inside.
You can remove your Floppy Disk controller inside of VirtualBox (if enabled) and instead add a virtual optical disk located at src > basekernel.iso 
