### PR TITLE
Remove basekernel.img from make build

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -7,6 +7,7 @@ all: basekernel.iso
 
 basekernel.iso: basekernel.img
 	genisoimage -J -R -o basekernel.iso -b basekernel.img basekernel.img
+	rm basekernel.img
 
 basekernel.img: bootblock kernel
 	cat bootblock kernel > basekernel.img


### PR DESCRIPTION
Remove basekernel.img after building basekernel.iso.
