### PR TITLE
Read from disk at block and offset

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,4 @@
-OBJECTS=kernelcore.o main.o console.o memory.o keyboard.o clock.o interrupt.o pic.o ata.o string.o graphics.o font.o syscall.o syscall_handler.o process.o mutex.o list.o pagetable.o rtc.o
+OBJECTS=kernelcore.o main.o console.o memory.o keyboard.o clock.o interrupt.o pic.o ata.o string.o graphics.o font.o syscall.o syscall_handler.o process.o mutex.o list.o pagetable.o rtc.o disk.o
 
 KERNEL_CCFLAGS=-Wall -c -ffreestanding -m32 -march=i386
 KERNEL_LDFLAGS=-m elf_i386

--- a/src/ata.c
+++ b/src/ata.c
@@ -13,8 +13,6 @@ See the file LICENSE for details.
 #include "process.h"
 #include "mutex.h"
 
-#define ATA_BLOCKSIZE 512
-
 #define ATA_IRQ0	32+14
 #define ATA_IRQ1	32+15
 #define ATA_IRQ2	32+11
@@ -389,7 +387,7 @@ void ata_init()
 
 	console_printf("ata: probing devices\n");
 
-	for(i=0;i<4;i++) {
+	for(i=0;i<1;i++) {
 		if(ata_probe(i,&nblocks,&blocksize,longname)) {
 
 			console_printf("ata unit %d: %s %d MB %s\n",i,blocksize==512 ? "ata disk" : "atapi cdrom", nblocks*blocksize/1024/1024,longname);

--- a/src/ata.h
+++ b/src/ata.h
@@ -7,6 +7,8 @@ See the file LICENSE for details.
 #ifndef ATA_H
 #define ATA_H
 
+#define ATA_BLOCKSIZE 512
+
 void ata_init();
 
 void ata_reset( int unit );

--- a/src/disk.c
+++ b/src/disk.c
@@ -1,0 +1,68 @@
+/*
+Copyright (C) 2015 The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file LICENSE for details.
+*/
+
+/*
+ * disk.c
+ */
+
+#include "disk.h"
+#include "ata.h"
+#include "string.h"
+#include "console.h"
+
+#define DEFAULT_ATA_UNIT 0
+
+int disk_write(char *source, int block, int offset, int num_bytes)
+{
+	/*
+	 * Still needs to be implemented!!
+	 */
+	return 0;
+}
+
+/**
+ * @brief Read in data from a particular disk block
+ * @details Read exactly num_bytes characters from a specified block and offset
+ * @param destination
+ * @param start_block_index
+ * @param offset
+ * @param num_bytes
+ * @return number of bytes read
+ */
+int disk_read(char *destination, int start_block_index, int offset, int num_bytes)
+{
+	int blocks_needed = ((offset + num_bytes) / ATA_BLOCKSIZE) + 1;
+	if( ((offset + num_bytes) % ATA_BLOCKSIZE) == 0)
+		blocks_needed--;
+
+
+	int blocks_read_in = 0;
+	char block_buffer[ATA_BLOCKSIZE];
+	int memcpy_offset;
+	int bytes_in_destination = 0;
+	int bytes_after_block_offset; // Usually ATA_BLOCKSIZE except on first block with offset
+
+	//Take one block at a time for memory and performance and such
+	for(blocks_read_in = 0; blocks_read_in < blocks_needed; blocks_read_in++){
+		ata_read(DEFAULT_ATA_UNIT, block_buffer, 1, start_block_index + blocks_read_in);
+		if(blocks_read_in == 0)
+		{
+			memcpy_offset = offset;
+			bytes_after_block_offset = ATA_BLOCKSIZE - offset;
+		}
+		else
+		{
+			memcpy_offset = 0;
+			bytes_after_block_offset = ATA_BLOCKSIZE;
+		}
+		int bytes_to_copy = ((bytes_in_destination + bytes_after_block_offset) > num_bytes) ? num_bytes - bytes_in_destination : bytes_after_block_offset;
+
+		memcpy(destination, block_buffer + memcpy_offset, bytes_to_copy);
+		bytes_in_destination += bytes_to_copy;
+	}
+
+	return bytes_in_destination;
+}

--- a/src/disk.h
+++ b/src/disk.h
@@ -1,0 +1,18 @@
+/*
+Copyright (C) 2015 The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file LICENSE for details.
+*/
+
+/*
+ * disk.h
+ */
+
+#ifndef DISK_H
+#define DISK_H
+
+int disk_write(char *source, int block, int offset, int num_bytes);
+
+int disk_read(char *destination, int block, int offset, int num_bytes);
+
+#endif /* DISK_H */

--- a/src/main.c
+++ b/src/main.c
@@ -17,6 +17,7 @@ See the file LICENSE for details.
 #include "syscall.h"
 #include "rtc.h"
 #include "kernelcore.h"
+#include "disk.h"
 
 /*
 This is the C initialization point of the kernel.
@@ -45,10 +46,19 @@ process_init() is a big step.  This initializes the process table, but also give
 
 	ata_init();
 
+
 	console_printf("\nBASEKERNEL READY:\n");
 
     //change text color to white after bootup
     console_set_fgcolor(255,255,255);
+
+    char read_buffer[25];
+    disk_read(read_buffer, 4, 5, 25);
+    read_buffer[24] = '\0';
+
+    ata_write(0, "1234567890ABCEFGHIJKLMNOPQRSTUVWXYZ", 1, 4);
+
+    console_printf("contents: %s\n", read_buffer);
 
 	while(1) {
 		keyboard_read_str();


### PR DESCRIPTION
Allows use of disk read at a specified block and offset.
You can read a specified number of bytes and save it into a buffer.
Tested by ata_write() of a test string to a particular block and
then loading in 25 bytes of the string at a 5 byte offset. The
correct portion of the written string was echoed back to the console.
