### PR TITLE
Added Windowing System

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,4 @@
-OBJECTS=kernelcore.o main.o console.o $(MEMORY_OBJS) keyboard.o clock.o interrupt.o pic.o ata.o string.o graphics.o font.o syscall.o syscall_handler.o process.o mutex.o list.o pagetable.o rtc.o disk.o math.o
+OBJECTS=kernelcore.o main.o console.o $(MEMORY_OBJS) keyboard.o clock.o interrupt.o pic.o ata.o string.o graphics.o font.o syscall.o syscall_handler.o process.o mutex.o list.o pagetable.o rtc.o disk.o math.o window.o
 
 MEMORY_OBJS=memory_raw.o kmalloc.o
 

--- a/src/graphics.c
+++ b/src/graphics.c
@@ -12,6 +12,8 @@ See the file LICENSE for details.
 
 #define ARC_DT 0.01
 
+static int bounds_x_1, bounds_x_2, bounds_y_1, bounds_y_2;
+
 int graphics_width() {
     return video_xres;
 }
@@ -20,7 +22,31 @@ int graphics_height() {
     return video_yres;
 }
 
+void graphics_init() {
+    graphics_clear_bounds();
+}
+
+void graphics_set_bounds(int x, int y, int w, int h) {
+    bounds_x_1 = x < 0 ? 0 : x;
+    bounds_x_2 = x + w >= video_xres ? video_xres - 1 : x + w;
+    bounds_y_1 = y < 0 ? 0 : y;
+    bounds_y_2 = y + h >= video_yres ? video_yres - 1 : y + h;
+}
+
+void graphics_clear_bounds() {
+    // Clearing bounds actually just sets the bounds to be the edges of
+    // the screen. This allows us to ensure we don't draw outside of screen memory
+    bounds_x_1 = 0;
+    bounds_x_2 = video_xres - 1;
+    bounds_y_1 = 0;
+    bounds_y_2 = video_yres - 1;
+}
+
 static inline void plot_pixel(int x, int y, struct graphics_color c) {
+    // Check to make sure that we are not drawing out of bounds
+    if (x < bounds_x_1 || x > bounds_x_2 || y < bounds_y_1 || y > bounds_y_2) {
+        return;
+    }
     uint8_t *v = video_buffer + video_xbytes * y + x * 3;
     v[2] = c.r;
     v[1] = c.g;

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -19,6 +19,32 @@ int graphics_width();
 int graphics_height();
 
 /**
+ * @brief Initializes the graphics system
+ * @details Sets up the initial drawing bounds of the system
+ * and prepares to being drawing
+ */
+void graphics_init();
+
+/**
+ * @brief Sets bounds for restricted drawing
+ * @details This will restrict all drawing to the given area of the screen.
+ * Drawing outside this area will have no effect
+ *
+ * @param x The x position of the top left corner of the bounding box
+ * @param y The y position of the top left corner of the bounding box
+ * @param width The width of the bounding box
+ * @param height The height of the bounding box
+ */
+void graphics_set_bounds(int x, int y, int width, int height);
+
+/**
+ * @brief Clears the graphics drawing restrictions
+ * @details This removes any restriction on drawing area that was added
+ * by graphics_set_bounds
+ */
+void graphics_clear_bounds();
+
+/**
  * @brief Draws a line on the display from (x1, y1) to (x2, y2)
  * @details Order of points does not matter. Points outside of display will be rounded to the closest edge
  *
@@ -44,7 +70,7 @@ void graphics_line(int x1, int y1, int x2, int y2, struct graphics_color c);
  * @param graphics_color The color to draw in
  */
 void graphics_arc(int x, int y, double r, double start_theta, double end_theta,
-				  struct graphics_color c);
+                  struct graphics_color c);
 
 /**
  * @brief Draws a circle centered at given point

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -21,7 +21,7 @@ int graphics_height();
 /**
  * @brief Initializes the graphics system
  * @details Sets up the initial drawing bounds of the system
- * and prepares to being drawing
+ * and prepares to begin drawing
  */
 void graphics_init();
 

--- a/src/main.c
+++ b/src/main.c
@@ -28,6 +28,7 @@ Now we initialize each subsystem in the proper order:
 */
 
 int kernel_main() {
+    graphics_init();
     console_init();
 
     console_printf("video: %d x %d\n", video_xres, video_yres, video_xbytes);

--- a/src/window.c
+++ b/src/window.c
@@ -1,0 +1,68 @@
+/*
+Copyright (C) 2015 The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file LICENSE for details.
+*/
+
+#include "window.h"
+#include "memory.h"
+
+// This function prepares to draw in a window by setting up its boundary
+// restrictions.
+// THIS FUNCTION SHOULD ALWAYS BE CALLED BEFORE MAKING A GRAPHICS DRAW
+// CALL IN THE WINDOW SYSTEM
+static inline void window_begin_draw(struct window *w) {
+    graphics_set_bounds(w->x, w->y, w->width, w->height);
+}
+
+// This function removes the restrictions used to enforce window clipping
+// on the graphics system
+// THIS FUNCTION SHOULD ALWAYS BE CALLED IF window_begin_draw WAS CALLED
+// TO FINISH THE DRAW
+static inline void window_end_draw() {
+    graphics_clear_bounds();
+}
+
+struct window *window_create(int x, int y, int width, int height) {
+    struct window *w = kmalloc(sizeof(*w));
+
+    w->x = x;
+    w->y = y;
+    w->width = width;
+    w->height = height;
+
+    return w;
+}
+
+void window_draw_line(struct window *w, int x1, int y1, int x2, int y2, struct graphics_color color) {
+    window_begin_draw(w);
+    graphics_line(x1 + w->x, y1 + w->y, x2 + w->x, y2 + w->y, color);
+    window_end_draw();
+}
+
+void window_draw_arc(struct window *w, int x, int y, double r, double start_theta, double end_theta, struct graphics_color color) {
+    window_begin_draw(w);
+    graphics_arc(x + w->x, y + w->y, r, start_theta, end_theta, color);
+    window_end_draw();
+}
+
+void window_draw_circle(struct window *w, int x, int y, double r, struct graphics_color color) {
+    window_begin_draw(w);
+    graphics_circle(x + w->x, y + w->y, r, color);
+    window_end_draw();
+}
+
+void window_draw_char(struct window *w, int x, int y, char ch, struct graphics_color fgcolor,
+                      struct graphics_color bgcolor) {
+    window_begin_draw(w);
+    graphics_char(x + w->x, y + w->y, ch, fgcolor, bgcolor);
+    window_end_draw();
+}
+
+void window_draw_bitmap(struct window *w, int x, int y, int width, int height, uint8_t * data,
+                     struct graphics_color fgcolor,
+                     struct graphics_color bgcolor) {
+    window_begin_draw(w);
+    graphics_bitmap(x + w->x, y + w->y, width, height, data, fgcolor, bgcolor);
+    window_end_draw();
+}

--- a/src/window.c
+++ b/src/window.c
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2015 The University of Notre Dame
+Copyright (C) 2016 The University of Notre Dame
 This software is distributed under the GNU General Public License.
 See the file LICENSE for details.
 */

--- a/src/window.h
+++ b/src/window.h
@@ -1,0 +1,110 @@
+/*
+Copyright (C) 2015 The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file LICENSE for details.
+*/
+
+#ifndef WINDOW_H
+#define WINDOW_H
+
+#include "graphics.h"
+
+struct window {
+    int x;
+    int y;
+    int width;
+    int height;
+    struct graphics_color border_color;
+    struct graphics_color background_color;
+};
+
+/**
+ * @brief Creates a window for given dimens
+ * @details Creates a window with the given location and size
+ *
+ * @param x The x position of the window, relative to the screen
+ * @param y The y position of the window, relative to the screen
+ * @param width The width of the window in pixels
+ * @param height The height of the window in pixels
+ * @return A pointer to the window
+ */
+struct window *window_create(int x, int y, int width, int height);
+
+/**
+ * @brief Draws a line in the window
+ * @details Draws a line at given position in the window
+ * It will be clipped if it extends outside the window
+ * All positions are realtive to the window
+ * @param window The window to draw in
+ * @param x1 The x position of the first point in the line
+ * @param y1 The position of the first point in the line
+ * @param x2 The x position of the second point in the line
+ * @param y2 The y position of the second point in the line
+ * @param color The color of the line
+ */
+void window_draw_line(struct window *w, int x1, int y1, int x2, int y2, struct graphics_color color);
+
+/**
+ * @brief Draws an arc in the window
+ * @details Draws an arc with given size and center inside the window
+ * Curves existing outside the window bounds will be clipped. All points
+ * relative to the window
+ *
+ * @param window The window to draw in
+ * @param x The x position of the center of the arc
+ * @param y The y position of the center of the arc
+ * @param r The radius of the arc
+ * @param start_theta The starting angle of the arc
+ * @param end_theta The ending angle of the arc
+ * @param color The color to draw in
+ */
+void window_draw_arc(struct window *w, int x, int y, double r, double start_theta, double end_theta, struct graphics_color c);
+
+/**
+ * @brief Draws a circle in the window
+ * @details Draws a circle of given size and location in the window.
+ * Curves outside the windows bounds will be clipped. All locations
+ * relative to the window
+ *
+ * @param window The window to draw in
+ * @param x The x position of the center of the window
+ * @param y The y position of the center of the window
+ * @param r The radius of the circle
+ * @param color The color to draw in
+ */
+void window_draw_circle(struct window *w, int x, int y, double r, struct graphics_color color);
+
+/**
+ * @brief Draws a character in the window
+ * @details Draws given character data in the window. Draws outside the bounds
+ * of the window will be clipped. All locations relative to the window
+ *
+ * @param window The window to draw in
+ * @param x The x position of the top left corner of the char
+ * @param y The y position of the top left corner of the char
+ * @param ch The character to draw
+ * @param fgcolor The color to draw the character
+ * @param bgcolor The color to draw the negative space
+ */
+void window_draw_char(struct window *w, int x, int y, char ch, struct graphics_color fgcolor,
+                      struct graphics_color bgcolor);
+
+/**
+ * @brief Draws data to window
+ * @details Draws the given graphics data to the screen within the given window
+ * Dawing outside the bounds of the window will result in clipping. All locations
+ * relative to the window
+ *
+ * @param window The window to draw in
+ * @param x The x position of the top left corner
+ * @param y The y position of the top left corner
+ * @param width The width of the data to draw
+ * @param height The height of the data to draw
+ * @param data The data to draw
+ * @param fgcolor The color to draw in
+ * @param bgcolor The color of negative space
+ */
+void window_draw_bitmap(struct window *w, int x, int y, int width, int height, uint8_t * data,
+                     struct graphics_color fgcolor,
+                     struct graphics_color bgcolor); 
+#endif

--- a/src/window.h
+++ b/src/window.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2015 The University of Notre Dame
+Copyright (C) 2016 The University of Notre Dame
 This software is distributed under the GNU General Public License.
 See the file LICENSE for details.
 */
@@ -35,9 +35,9 @@ struct window *window_create(int x, int y, int width, int height);
  * @details Draws a line at given position in the window
  * It will be clipped if it extends outside the window
  * All positions are realtive to the window
- * @param window The window to draw in
+ * @param w The window to draw in
  * @param x1 The x position of the first point in the line
- * @param y1 The position of the first point in the line
+ * @param y1 The y position of the first point in the line
  * @param x2 The x position of the second point in the line
  * @param y2 The y position of the second point in the line
  * @param color The color of the line
@@ -50,12 +50,12 @@ void window_draw_line(struct window *w, int x1, int y1, int x2, int y2, struct g
  * Curves existing outside the window bounds will be clipped. All points
  * relative to the window
  *
- * @param window The window to draw in
+ * @param w The window to draw in
  * @param x The x position of the center of the arc
  * @param y The y position of the center of the arc
  * @param r The radius of the arc
- * @param start_theta The starting angle of the arc
- * @param end_theta The ending angle of the arc
+ * @param start_theta The starting angle of the arc, between 0 and 2*PI. See sin/cos
+ * @param end_theta The ending angle of the arc, between 0 and 2*PI. See sin/cos
  * @param color The color to draw in
  */
 void window_draw_arc(struct window *w, int x, int y, double r, double start_theta, double end_theta, struct graphics_color c);
@@ -66,9 +66,9 @@ void window_draw_arc(struct window *w, int x, int y, double r, double start_thet
  * Curves outside the windows bounds will be clipped. All locations
  * relative to the window
  *
- * @param window The window to draw in
- * @param x The x position of the center of the window
- * @param y The y position of the center of the window
+ * @param w The window to draw in
+ * @param x The x position of the center of the circle, relative to the window
+ * @param y The y position of the center of the circle, relative to the window
  * @param r The radius of the circle
  * @param color The color to draw in
  */
@@ -79,7 +79,7 @@ void window_draw_circle(struct window *w, int x, int y, double r, struct graphic
  * @details Draws given character data in the window. Draws outside the bounds
  * of the window will be clipped. All locations relative to the window
  *
- * @param window The window to draw in
+ * @param w The window to draw in
  * @param x The x position of the top left corner of the char
  * @param y The y position of the top left corner of the char
  * @param ch The character to draw
@@ -92,10 +92,10 @@ void window_draw_char(struct window *w, int x, int y, char ch, struct graphics_c
 /**
  * @brief Draws data to window
  * @details Draws the given graphics data to the screen within the given window
- * Dawing outside the bounds of the window will result in clipping. All locations
+ * Drawing outside the bounds of the window will result in clipping. All locations
  * relative to the window
  *
- * @param window The window to draw in
+ * @param w The window to draw in
  * @param x The x position of the top left corner
  * @param y The y position of the top left corner
  * @param width The width of the data to draw


### PR DESCRIPTION
This adds the basic windowing system for Nunya. The windowing system
provides wrappers for graphics drawing, and enforces only drawing within
a window bounds. This is accomplished by adding a new feature to the
graphics system which is an optional restrcited range. Windows use this
to enforce clipping in a simple manner, and then clear it when finished.
It is also used to ensure we are not attempting to draw offscreen and
therefore not accessing other parts of memory.
