### PR TITLE
Separate memory and kmalloc modules

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,6 @@
-OBJECTS=kernelcore.o main.o console.o memory.o keyboard.o clock.o interrupt.o pic.o ata.o string.o graphics.o font.o syscall.o syscall_handler.o process.o mutex.o list.o pagetable.o rtc.o disk.o math.o
+OBJECTS=kernelcore.o main.o console.o $(MEMORY_OBJS) keyboard.o clock.o interrupt.o pic.o ata.o string.o graphics.o font.o syscall.o syscall_handler.o process.o mutex.o list.o pagetable.o rtc.o disk.o math.o
+
+MEMORY_OBJS=memory_raw.o kmalloc.o
 
 KERNEL_CCFLAGS=-Wall -c -ffreestanding -m32 -march=i386
 KERNEL_LDFLAGS=-m elf_i386

--- a/src/kmalloc.h
+++ b/src/kmalloc.h
@@ -1,0 +1,33 @@
+/*
+Copyright (C) 2015 The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file LICENSE for details.
+*/
+
+#ifndef KMALLOC_H
+#define KMALLOC_H
+
+/**
+ * @brief   Kernel allocation of the parameter requested size of memory
+ * @details Iterates through a linked list of pages for a large enough gap of
+ *          contiguous free slots of fixed size. If no page for kmalloc has a
+ *          large enough gap, a new gap is asked from memory.
+ *
+ * @param   size The size in bytes of the chunk of memory requested from
+ *          kmalloc, not to exceed 3632
+ * @return  A pointer to the allocated memory that needs to be kfree()'d to be
+ *          released.
+ */
+void *kmalloc(unsigned int size);
+
+/**
+ * @brief   Frees previously allocated memory in the kernel's portion of memory
+ * @detail  Takes the given pointer, and finding the appropriate page in
+ *          memory, marks that region as free on that page's kmalloc_page_info.
+ *
+ * @param   to_free The pointer to the segment of memory to be free'd. This
+ *          should have been obtained from a call to kmalloc.
+ */
+void kfree(void* to_free);
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -6,6 +6,7 @@ See the file LICENSE for details.
 
 #include "console.h"
 #include "memory.h"
+#include "memory_raw.h"     // memory_init
 #include "process.h"
 #include "interrupt.h"
 #include "keyboard.h"

--- a/src/memory_raw.c
+++ b/src/memory_raw.c
@@ -1,0 +1,113 @@
+/*
+Copyright (C) 2015 The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file LICENSE for details.
+*/
+
+#include "memory_raw.h"
+#include "process.h"
+#include "console.h"
+#include "kerneltypes.h"
+#include "string.h"
+#include "memorylayout.h"
+#include "kernelcore.h"
+#include "pagetable.h"
+
+static uint32_t pages_free = 0;
+static uint32_t pages_total = 0;
+
+static uint32_t *freemap = 0;
+static uint32_t freemap_bits = 0;
+static uint32_t freemap_bytes = 0;
+static uint32_t freemap_cells = 0;
+static uint32_t freemap_pages = 0;
+
+static void *alloc_memory_start = (void *)ALLOC_MEMORY_START;
+
+#define CELL_BITS (8*sizeof(*freemap))
+
+void memory_init() {
+    int i;
+
+    pages_total = (total_memory * 1024) / (PAGE_SIZE / 1024);
+    pages_free = pages_total;
+    console_printf("memory: %d MB (%d KB) total\n",
+                   (pages_free * PAGE_SIZE) / MEGA,
+                   (pages_free * PAGE_SIZE) / KILO);
+
+    freemap = alloc_memory_start;
+    freemap_bits = pages_total;
+    freemap_bytes = 1 + freemap_bits / 8;
+    freemap_cells = 1 + freemap_bits / CELL_BITS;
+    freemap_pages = 1 + freemap_bytes / PAGE_SIZE;
+
+    console_printf("memory: %d bits %d bytes %d cells %d pages\n",
+                   freemap_bits, freemap_bytes, freemap_cells, freemap_pages);
+
+    memset(freemap, 0xff, freemap_bytes);
+    for (i = 0; i < freemap_pages; i++) {
+        memory_alloc_page(0);
+    }
+
+    // This is ahack that I don't understand yet.
+    // vmware doesn't like the use of a particular page
+    // close to 1MB, but what it is used for I don't know.
+
+    freemap[0] = 0x0;
+
+    console_printf("memory: %d MB (%d KB) available\n",
+                   (pages_free * PAGE_SIZE) / MEGA,
+                   (pages_free * PAGE_SIZE) / KILO);
+}
+
+uint32_t memory_pages_free() {
+    return pages_free;
+}
+
+uint32_t memory_pages_total() {
+    return pages_total;
+}
+
+void *memory_alloc_page(bool zeroit) {
+    uint32_t i, j;
+    uint32_t cellmask;
+    uint32_t pagenumber;
+    void *pageaddr;
+
+    if (!freemap) {
+        console_printf("memory: not initialized yet!\n");
+        return 0;
+    }
+
+    for (i = 0; i < freemap_cells; i++) {
+        if (freemap[i] != 0) {
+            for (j = 0; j < CELL_BITS; j++) {
+                cellmask = (1 << j);
+                if (freemap[i] & cellmask) {
+                    freemap[i] &= ~cellmask;
+                    pagenumber = i * CELL_BITS + j;
+                    pageaddr = (pagenumber << PAGE_BITS) + alloc_memory_start;
+                    if (zeroit) {
+                        memset(pageaddr, 0, PAGE_SIZE);
+                    }
+                    pages_free--;
+                    return pageaddr;
+                }
+            }
+        }
+    }
+
+    console_printf("memory: WARNING: everything allocated\n");
+    halt();
+
+    return 0;
+}
+
+void memory_free_page(void *pageaddr) {
+    uint32_t pagenumber = (pageaddr - alloc_memory_start) >> PAGE_BITS;
+    uint32_t cellnumber = pagenumber / CELL_BITS;
+    uint32_t celloffset = pagenumber % CELL_BITS;
+    uint32_t cellmask = (1 << celloffset);
+    freemap[cellnumber] |= cellmask;
+    pages_free++;
+}

--- a/src/memory_raw.h
+++ b/src/memory_raw.h
@@ -4,9 +4,13 @@ This software is distributed under the GNU General Public License.
 See the file LICENSE for details.
 */
 
-#ifndef MEMORY_H
-#define MEMORY_H
+#ifndef MEMORY_RAW_H
+#define MEMORY_RAW_H
 
-#include "kmalloc.h"
+#include "kerneltypes.h"
+
+void memory_init();
+void *memory_alloc_page(bool zeroit);
+void memory_free_page(void *addr);
 
 #endif

--- a/src/pagetable.c
+++ b/src/pagetable.c
@@ -5,7 +5,7 @@ See the file LICENSE for details.
 */
 
 #include "pagetable.h"
-#include "memory.h"
+#include "memory_raw.h"
 #include "string.h"
 #include "kernelcore.h"
 
@@ -33,7 +33,7 @@ struct pagetable {
 };
 
 struct pagetable *pagetable_create() {
-    return memory_alloc_page(1);
+    return (struct pagetable *)memory_alloc_page(1);
 }
 
 void pagetable_init(struct pagetable *p) {

--- a/src/process.c
+++ b/src/process.c
@@ -14,6 +14,8 @@ See the file LICENSE for details.
 #include "memorylayout.h"
 #include "kernelcore.h"
 
+#include "memory_raw.h" // memory_alloc_page, memory_free_page
+
 struct process *current = 0;
 struct list ready_list = { 0, 0 };
 
@@ -53,7 +55,7 @@ static void process_stack_init(struct process *p) {
 struct process *process_create(unsigned code_size, unsigned stack_size) {
     struct process *p;
 
-    p = memory_alloc_page(1);
+    p = (struct process *)memory_alloc_page(1);
 
     p->pagetable = pagetable_create();
     pagetable_init(p->pagetable);


### PR DESCRIPTION
Separate memory and kmalloc modules into different files.

Resolved previous issue in NunyaOS/Nunya#23 (reverted in #25), where the build succeeds but the machine crashes. The problem is in [src/process.c:58](https://github.com/shuyangli/Nunya/blob/4a62e4e0525743fdea2bea72cb999e1c4405ef5b/src/process.c#L58), where previously a `kmalloc` call fails somehow.

Tested by compiling and running, and the code works fine.
