### PR TITLE
[NUN-9] Block off 0x1a0000 thru 0x1c0000

### DIFF
--- a/src/memory_raw.c
+++ b/src/memory_raw.c
@@ -55,6 +55,10 @@ void memory_init() {
 
     freemap[0] = 0x0;
 
+    // VirtualBox doesn't like memory address 0x1A0000 through 0x1C0000
+    // so block it off
+    freemap[5] = 0x0;
+
     console_printf("memory: %d MB (%d KB) available\n",
                    (pages_free * PAGE_SIZE) / MEGA,
                    (pages_free * PAGE_SIZE) / KILO);


### PR DESCRIPTION
VirtualBox halts when any address in this range is touched
(dereferenced), so we block it off.

Tested by allocating memory with this chunk blocked off, and the system
is able to allocate all available memory.
