### PR TITLE
Fix bug with slave PIC

### DIFF
--- a/src/pic.c
+++ b/src/pic.c
@@ -39,6 +39,7 @@ void pic_enable(uint8_t irq) {
         mask = mask & ~(1 << irq);
         outb(mask, pic_data[0]);
     } else {
+        irq -= 8;
         mask = inb(pic_data[1]);
         mask = mask & ~(1 << irq);
         outb(mask, pic_data[1]);
@@ -53,6 +54,7 @@ void pic_disable(uint8_t irq) {
         mask = mask | (1 << irq);
         outb(mask, pic_data[0]);
     } else {
+        irq -= 8;
         mask = inb(pic_data[1]);
         mask = mask | (1 << irq);
         outb(mask, pic_data[1]);


### PR DESCRIPTION
This solves a bug that prevented the slave PIC from working
properly. The PIC has a mask that indicates which IRQs it should listen
to, with a 1 indicating that IRQ should be ignored. Masks were not being
generated properly for IRQs that lived on the slave (>=8).

The mous uses IRQ 12, so this is a necessary fix for mouse interrupts.
Tested using mouse interrupts.
