### PR TITLE
[NUN-17] Correct kmalloc integer division

### DIFF
--- a/src/kmalloc.c
+++ b/src/kmalloc.c
@@ -126,7 +126,7 @@ int kmalloc_get_largest_gap_size(struct kmalloc_page_info *page_info) {
 void *kmalloc(unsigned int size) {
     uint16_t slots_needed = (size + sizeof(uint16_t)) / KMALLOC_SLOT_SIZE;
     //addresses integer division truncation
-    if (size % 8 != 0) {
+    if ((size + sizeof(uint16_t)) / KMALLOC_SLOT_SIZE) {
         slots_needed++;
     }
 


### PR DESCRIPTION
There was an error in taking (size % 8) as opposed to (size + 2) % 8, which caused issues with exact multiples of 8 being allocated.
Corrects [NUN-17].
[NUN-10] might be a dupe, investigating.
