### PR TITLE
[NUN-22] Add interrupt flag

### DIFF
--- a/src/interrupt.c
+++ b/src/interrupt.c
@@ -16,6 +16,9 @@ static interrupt_handler_t interrupt_handler_table[48];
 static uint32_t interrupt_count[48];
 static uint8_t interrupt_spurious[48];
 
+// Flag to record last interrupt before crashes
+uint32_t last_interrupt = -1;
+
 static const char *exception_names[] = {
     "division by zero",
     "debug exception",
@@ -88,6 +91,7 @@ void interrupt_init() {
 }
 
 void interrupt_handler(int i, int code) {
+    last_interrupt = i;
     (interrupt_handler_table[i]) (i, code);
     interrupt_acknowledge(i);
     interrupt_count[i]++;

--- a/src/process.c
+++ b/src/process.c
@@ -19,6 +19,8 @@ See the file LICENSE for details.
 struct process *current = 0;
 struct list ready_list = { 0, 0 };
 
+extern uint32_t last_interrupt;
+
 void process_init() {
     // Create a dummy process with no code and no data, and load its pagetable
     // Even though it's dummy, at least kernel memory is direct mapped, so
@@ -166,6 +168,7 @@ void process_wakeup_all(struct list *q) {
 }
 
 void process_dump(struct process *p) {
+    console_printf("last interrupt: %d\n", last_interrupt);
     struct x86_stack *s =
         (struct x86_stack *)(p->kstack + PAGE_SIZE - sizeof(*s));
     console_printf("kstack: %x\n", p->kstack);


### PR DESCRIPTION
This adds a flag to track the last interrupt that happened. This is
useful for crashes, and it has been added to the process_dump for this
reason.

Tested by dumping the current process and checking the last interrupt,
which was a keyboard interrupt
