### PR TITLE
Add command to enter user mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ bootblock
 kernel
 basekernel.img
 basekernel.iso
+test_iso.iso
+

--- a/src/Makefile
+++ b/src/Makefile
@@ -6,7 +6,7 @@ TEST_OBJS=module_tests.o testing.o tests.o
 KERNEL_CCFLAGS=-Wall -c -ffreestanding -m32 -march=i386
 KERNEL_LDFLAGS=-m elf_i386
 
-all: basekernel.iso
+all: basekernel.iso test_iso.iso
 
 basekernel.iso: basekernel.img
 	genisoimage -J -R -o basekernel.iso -b basekernel.img basekernel.img
@@ -22,6 +22,12 @@ bootblock: bootblock.o
 kernel: ${OBJECTS}
 	ld ${KERNEL_LDFLAGS} -Ttext 0x10000 -s --oformat binary ${OBJECTS} -o $@
 
+test_iso.iso: userproc
+	mkdir ./test_iso && mv ./userproc ./test_iso/userproc && genisoimage -o ../test_iso.iso ./test_iso/ && rm -r ./test_iso
+
+userproc: test_userproc.o syscall.o
+	ld ${KERNEL_LDFLAGS} -Ttext 0x80000000 -s --oformat binary test_userproc.o syscall.o -o $@
+
 %.o: %.c
 	gcc ${KERNEL_CCFLAGS} $< -o $@
 
@@ -29,4 +35,4 @@ kernel: ${OBJECTS}
 	gcc ${KERNEL_CCFLAGS} $< -o $@
 
 clean:
-	rm -rf basekernel.iso basekernel.img bootblock kernel *.o
+	rm -rf basekernel.iso basekernel.img bootblock userproc kernel ./test_iso *.o

--- a/src/Makefile
+++ b/src/Makefile
@@ -25,7 +25,7 @@ kernel: ${OBJECTS}
 test_iso.iso: userproc
 	mkdir ./test_iso && mv ./userproc ./test_iso/userproc && genisoimage -o ../test_iso.iso ./test_iso/ && rm -r ./test_iso
 
-userproc: test_userproc.o syscall.o
+userproc: test_userproc.o syscall.h syscall.o
 	ld ${KERNEL_LDFLAGS} -Ttext 0x80000000 -s --oformat binary test_userproc.o syscall.o -o $@
 
 %.o: %.c

--- a/src/cmd_line.h
+++ b/src/cmd_line.h
@@ -28,4 +28,10 @@ void cmd_line_init();
  */
 void cmd_line_show_prompt();
 
+/**
+ * @brief Run a designated test user process
+ * @details Load a designated user process from test_iso.iso and execute it.
+ */
+void cmd_line_run_userproc();
+
 #endif

--- a/src/process.c
+++ b/src/process.c
@@ -22,7 +22,7 @@ struct list ready_list = { 0, 0 };
 void process_init() {
     // Create a dummy process with no code and no data, and load its pagetable
     // Even though it's dummy, at least kernel memory is direct mapped, so
-    // kernel code can run as usual
+    // kernel code can run as usual (specifically to enable ata interrupts)
     current = process_create(0, 0);
     pagetable_load(current->pagetable);
 
@@ -179,4 +179,8 @@ void process_dump(struct process *p) {
     console_printf("ebp: %x\n", s->regs1.ebp);
     console_printf("esp: %x\n", s->esp);
     console_printf("eip: %x\n", s->eip);
+}
+
+void __process_set_initial_process_ready(struct process *p) {
+    list_push_tail(&ready_list, &p->node);
 }

--- a/src/process.h
+++ b/src/process.h
@@ -42,6 +42,8 @@ void process_wait(struct list *q);
 void process_wakeup(struct list *q);
 void process_wakeup_all(struct list *q);
 
+void __process_set_initial_process_ready(struct process *p);
+
 extern struct process *current;
 
 #endif

--- a/src/test_userproc.c
+++ b/src/test_userproc.c
@@ -1,0 +1,15 @@
+int main();
+int _start() {
+    return main();
+
+    // invoke system call that kills the process
+}
+
+#include "syscall.h"
+
+int main() {
+    while (1) {
+        testcall(37);
+    }
+    return 0;
+}


### PR DESCRIPTION
This contains a simple user program which calls a test system call in an infinite loop, and a console command `runproc` that, when invoked, launches the user program in user mode.

Tested by compiling and running the command, and the user process launches as expected.
