### PR TITLE
Add Border and String drawing

### DIFF
--- a/src/window.c
+++ b/src/window.c
@@ -7,6 +7,9 @@ See the file LICENSE for details.
 #include "window.h"
 #include "memory.h"
 
+#define CHARACTER_W 8
+#define CHARACTER_H 8
+
 // This function prepares to draw in a window by setting up its boundary
 // restrictions.
 // THIS FUNCTION SHOULD ALWAYS BE CALLED BEFORE MAKING A GRAPHICS DRAW
@@ -31,7 +34,21 @@ struct window *window_create(int x, int y, int width, int height) {
     w->width = width;
     w->height = height;
 
+    // Draw the border
+    struct graphics_color bc = {128,128,128};
+    window_set_border_color(w, bc);
+
     return w;
+}
+
+void window_set_border_color(struct window *w, struct graphics_color border_color) {
+    w->border_color = border_color;
+
+    // Draw the new border
+    window_draw_line(w, 0, 0, 0, w->height, border_color);
+    window_draw_line(w, 0, 0, w->width, 0, border_color);
+    window_draw_line(w, 0, w->height, w->width, w->height, border_color);
+    window_draw_line(w, w->width, 0, w->width, w->height, border_color);
 }
 
 void window_draw_line(struct window *w, int x1, int y1, int x2, int y2, struct graphics_color color) {
@@ -57,6 +74,23 @@ void window_draw_char(struct window *w, int x, int y, char ch, struct graphics_c
     window_begin_draw(w);
     graphics_char(x + w->x, y + w->y, ch, fgcolor, bgcolor);
     window_end_draw();
+}
+
+void window_draw_string(struct window *w, int x, int y, const char *str, struct graphics_color fgcolor,
+                        struct graphics_color bgcolor) {
+    int pos_h = 0;
+    int pos_w = 0;
+    while (*str) {
+        if (*str == '\n') {
+            pos_h += CHARACTER_H;
+            pos_w = 0;
+            str++;
+            continue;
+        }
+        window_draw_char(w, x + pos_w, y + pos_h, *str, fgcolor, bgcolor);
+        pos_w += CHARACTER_W;
+        str++;
+    }
 }
 
 void window_draw_bitmap(struct window *w, int x, int y, int width, int height, uint8_t * data,

--- a/src/window.h
+++ b/src/window.h
@@ -31,6 +31,14 @@ struct window {
 struct window *window_create(int x, int y, int width, int height);
 
 /**
+ * @brief Sets the border color of the window
+ * @details Sets the border color of the window and re-draws with the new color
+ *
+ * @param window The window whose border color to change
+ * @param graphics_color The new border color
+ */
+void window_set_border_color(struct window *w, struct graphics_color border_color);
+/**
  * @brief Draws a line in the window
  * @details Draws a line at given position in the window
  * It will be clipped if it extends outside the window
@@ -88,6 +96,21 @@ void window_draw_circle(struct window *w, int x, int y, double r, struct graphic
  */
 void window_draw_char(struct window *w, int x, int y, char ch, struct graphics_color fgcolor,
                       struct graphics_color bgcolor);
+
+/**
+ * @brief Draws a string in the window
+ * @details Draws the given string in the window. If the string extends beyond
+ * the bounds of the window, it will be clipped.
+ *
+ * @param window The window to draw in
+ * @param x The x position of the top left corner of the first character
+ * @param y The y position of the top right corner of the first character
+ * @param str The text to be drawn, null terminated
+ * @param graphics_color The color to draw the characters
+ * @param graphics_color The color to draw the negative space
+ */
+void window_draw_string(struct window *w, int x, int y, const char *str, struct graphics_color fgcolor,
+						struct graphics_color bgcolor);
 
 /**
  * @brief Draws data to window


### PR DESCRIPTION
This adds functions to draw borders of windows, and to draw strings in
windows. When a window is created, a default border color of grey
(128,128,128) is used. To change this, the window_set_border_color()
function must be used, so that the border can be redrawn in the new color.

Tested by creating a window and drawing text to it.
