### PR TITLE
Add debug functions for dumping memory addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ cd src
 make
 ```
 
+To enable optional debugging logging, run the following commands instead:
+```
+cd src
+make debug
+```
+
 That will create `basekernel.iso`, which is an image of an optical disk that can be mounted in a virtual machine.  Next, set up a virtual machine system
 like VMWare, VirtualBox, or Bochs, and direct it to use that image. In VirtualBox, for example, you can select `Type > Linux` and `Version > Other Linux (32-bit)`
 Finally, point the virtual machine to `src > basekernel.iso`

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,12 +1,17 @@
 OBJECTS=kernelcore.o main.o console.o $(MEMORY_OBJS) keyboard.o clock.o interrupt.o pic.o ata.o string.o graphics.o font.o syscall.o syscall_handler.o process.o mutex.o list.o pagetable.o rtc.o disk.o math.o window.o cmd_line.o $(TEST_OBJS) iso.o fs_terminal_commands.o
+OBJECTS+=$(DEBUG_OBJS)
 
 MEMORY_OBJS=memory_raw.o kmalloc.o
 TEST_OBJS=module_tests.o testing.o tests.o
+DEBUG_OBJS=debug_kernel.o
 
 KERNEL_CCFLAGS=-Wall -c -ffreestanding -m32 -march=i386
 KERNEL_LDFLAGS=-m elf_i386
 
 all: basekernel.iso
+
+debug: KERNEL_CCFLAGS += -DNUNYA_KDEBUG
+debug: basekernel.iso
 
 basekernel.iso: basekernel.img
 	genisoimage -J -R -o basekernel.iso -b basekernel.img basekernel.img

--- a/src/Makefile
+++ b/src/Makefile
@@ -33,5 +33,8 @@ kernel: ${OBJECTS}
 %.o: %.S
 	gcc ${KERNEL_CCFLAGS} $< -o $@
 
+%.s: %.c
+	gcc -Wall -S -ffreestanding -m32 -march=i386 $< -o $@
+
 clean:
 	rm -rf basekernel.iso basekernel.img bootblock kernel *.o

--- a/src/debug_kernel.c
+++ b/src/debug_kernel.c
@@ -1,0 +1,26 @@
+/*
+Copyright (C) 2015 The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file LICENSE for details.
+*/
+
+#include "debug_kernel.h"
+#include "console.h"
+
+void debug_dump_mem_from_addr(uint32_t *addr, int len) {
+#ifdef NUNYA_KDEBUG
+    int i;
+
+    console_printf("[DEBUG] Dumping stack starting from %x\n", addr);
+    console_printf("  addr   |   value\n");
+
+    if (len < 0) {
+        len = -len;
+        addr = addr - len + 1;
+    }
+
+    for (i = 0; i < len; ++i) {
+        printf("%x | %x\n", (addr + i), *(addr + i));
+    }
+#endif
+}

--- a/src/debug_kernel.h
+++ b/src/debug_kernel.h
@@ -1,0 +1,36 @@
+/*
+Copyright (C) 2015 The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file LICENSE for details.
+*/
+
+#ifndef DEBUG_KERNEL_H
+#define DEBUG_KERNEL_H
+
+#include "kerneltypes.h"
+
+// This is a set of functions we can call in kernel mode to facilitate
+// debugging in kernel mode. To enable them, uncomment the following definition:
+
+enum register_name_t {
+    reg_esi = 0,
+    reg_edi,
+    reg_ebp,
+    reg_esp
+};
+
+/**
+ * @brief   Dump memory content of a given length at a given address
+ * @detail  Dump memory content in hex, starting or ending at a given address
+ *          depending on the given length.
+ *
+ * @param   addr    The start or end address of memory to be dumped
+ * @param   len     The length of memory to be dumped in 4 bytes (32-bit
+ *                  integers). If len is positive, then we dump memory contents
+ *                  starting from addr and reach (addr + len); if len is
+ *                  negative, then we dump memory contents starting from (addr
+ *                  - |len|) and reach addr
+ */
+void debug_dump_mem_from_addr(uint32_t *addr, int len);
+
+#endif


### PR DESCRIPTION
As described.

These functions are used for tracing user stack when I'm debugging process loading.
