### PR TITLE
Window parent

### DIFF
--- a/src/cmd_line.c
+++ b/src/cmd_line.c
@@ -9,6 +9,8 @@ See the file LICENSE for details.
 #include "string.h"
 #include "testing.h"
 #include "fs_terminal_commands.h"
+#include "window.h"
+#include "graphics.h"
 
 #define KEYBOARD_BUFFER_SIZE 256
 
@@ -45,6 +47,9 @@ void cmd_line_attempt(const char *line) {
         cmd_line_ls(the_rest);
     } else if (strcmp("cat", first_word) == 0) {
         cmd_line_cat(the_rest);
+    } else if (strcmp("window_test", first_word) == 0) {
+        console_printf("\f");
+        window_hierarchy_test();
     }
     /*else if () {
      *...

--- a/src/main.c
+++ b/src/main.c
@@ -50,9 +50,6 @@ int kernel_main() {
 
     console_printf("\nBASEKERNEL READY:\n");
 
-    //change text color to white after bootup
-    console_set_fgcolor(255, 255, 255);
-
     cmd_line_init();
 
     while(1) {

--- a/src/window.c
+++ b/src/window.c
@@ -76,7 +76,7 @@ void window_draw_char(struct window *w, int x, int y, char ch, struct graphics_c
     window_end_draw();
 }
 
-void window_draw_string(struct window *w, int x, int y, const char *str, struct graphics_color fgcolor,
+void window_draw_string(struct window *w, int x, int y, char *str, struct graphics_color fgcolor,
                         struct graphics_color bgcolor) {
     int pos_h = 0;
     int pos_w = 0;

--- a/src/window.c
+++ b/src/window.c
@@ -15,7 +15,16 @@ See the file LICENSE for details.
 // THIS FUNCTION SHOULD ALWAYS BE CALLED BEFORE MAKING A GRAPHICS DRAW
 // CALL IN THE WINDOW SYSTEM
 static inline void window_begin_draw(struct window *w) {
-    graphics_set_bounds(w->x, w->y, w->width, w->height);
+    int x = w->x;
+    int y = w->y;
+    int width = w->width;
+    int height = w->height;
+    while(w->parent) {
+        w = w->parent;
+        x += w->x;
+        y += w->y;
+    }
+    graphics_set_bounds(x, y, width, height);
 }
 
 // This function removes the restrictions used to enforce window clipping
@@ -26,13 +35,14 @@ static inline void window_end_draw() {
     graphics_clear_bounds();
 }
 
-struct window *window_create(int x, int y, int width, int height) {
+struct window *window_create(int x, int y, int width, int height, struct window *parent) {
     struct window *w = kmalloc(sizeof(*w));
 
     w->x = x;
     w->y = y;
     w->width = width;
     w->height = height;
+    w->parent = parent;
 
     // Draw the border
     struct graphics_color bc = {128,128,128};

--- a/src/window.h
+++ b/src/window.h
@@ -110,8 +110,7 @@ void window_draw_char(struct window *w, int x, int y, char ch, struct graphics_c
  * @param graphics_color The color to draw the characters
  * @param graphics_color The color to draw the negative space
  */
-
-void window_draw_string(struct window *w, int x, int y, char *str, struct graphics_color fgcolor,
+void window_draw_string(struct window *w, int x, int y, const char *str, struct graphics_color fgcolor,
                         struct graphics_color bgcolor);
 
 /**
@@ -131,5 +130,12 @@ void window_draw_string(struct window *w, int x, int y, char *str, struct graphi
  */
 void window_draw_bitmap(struct window *w, int x, int y, int width, int height, uint8_t * data,
                      struct graphics_color fgcolor,
-                     struct graphics_color bgcolor); 
+                     struct graphics_color bgcolor);
+
+/**
+ * @brief Tests drawing in nested windows
+ * @details This creates nested windows and draws to them, to ensure
+ * that child windows are being correctly clipped
+ */
+void window_hierarchy_test();
 #endif

--- a/src/window.h
+++ b/src/window.h
@@ -10,6 +10,7 @@ See the file LICENSE for details.
 #include "graphics.h"
 
 struct window {
+    struct window *parent;
     int x;
     int y;
     int width;
@@ -26,9 +27,10 @@ struct window {
  * @param y The y position of the window, relative to the screen
  * @param width The width of the window in pixels
  * @param height The height of the window in pixels
+ * @param parent The parent window, or NULL if none
  * @return A pointer to the window
  */
-struct window *window_create(int x, int y, int width, int height);
+struct window *window_create(int x, int y, int width, int height, struct window *parent);
 
 /**
  * @brief Sets the border color of the window
@@ -110,7 +112,7 @@ void window_draw_char(struct window *w, int x, int y, char ch, struct graphics_c
  */
 
 void window_draw_string(struct window *w, int x, int y, char *str, struct graphics_color fgcolor,
-						struct graphics_color bgcolor);
+                        struct graphics_color bgcolor);
 
 /**
  * @brief Draws data to window

--- a/src/window.h
+++ b/src/window.h
@@ -33,7 +33,6 @@ struct window *window_create(int x, int y, int width, int height);
 /**
  * @brief Sets the border color of the window
  * @details Sets the border color of the window and re-draws with the new color
- *
  * @param window The window whose border color to change
  * @param graphics_color The new border color
  */
@@ -109,7 +108,8 @@ void window_draw_char(struct window *w, int x, int y, char ch, struct graphics_c
  * @param graphics_color The color to draw the characters
  * @param graphics_color The color to draw the negative space
  */
-void window_draw_string(struct window *w, int x, int y, const char *str, struct graphics_color fgcolor,
+
+void window_draw_string(struct window *w, int x, int y, char *str, struct graphics_color fgcolor,
 						struct graphics_color bgcolor);
 
 /**


### PR DESCRIPTION
This adds nested windows. When a window performs a draw, the actual location of that draw will be determined relative to the entire line of windows it is derived from. Windows will also be clipped by their parents bounds.    

This also adds a test that can be run at the command line, window_test, which tests the relative drawing and clipping of nested windows.
