### PR TITLE
Add Window System Calls

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,11 +1,14 @@
-OBJECTS=kernelcore.o main.o console.o $(MEMORY_OBJS) keyboard.o clock.o interrupt.o pic.o ata.o string.o graphics.o font.o syscall.o syscall_handler.o process.o mutex.o list.o pagetable.o rtc.o disk.o math.o window.o cmd_line.o $(TEST_OBJS) iso.o fs_terminal_commands.o
+OBJECTS=kernelcore.o main.o console.o $(MEMORY_OBJS) keyboard.o clock.o interrupt.o pic.o ata.o string.o font.o syscall.o syscall_handler.o process.o mutex.o list.o pagetable.o rtc.o disk.o math.o cmd_line.o $(TEST_OBJS) iso.o fs_terminal_commands.o
 OBJECTS+=$(DEBUG_OBJS)
 OBJECTS+=$(MOUSE_OBJS)
+OBJECTS+=$(WINDOW_OBJS)
+
 
 MOUSE_OBJS = mouse.o ps2.o
 MEMORY_OBJS=memory_raw.o kmalloc.o
 TEST_OBJS=module_tests.o testing.o tests.o
 DEBUG_OBJS=debug_kernel.o
+WINDOW_OBJS=window.o graphics.o syscall_handler_window.o
 
 KERNEL_CCFLAGS=-Wall -c -ffreestanding -m32 -march=i386
 KERNEL_LDFLAGS=-m elf_i386

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -8,12 +8,8 @@ See the file LICENSE for details.
 #define GRAPHICS_H
 
 #include "kerneltypes.h"
+#include "sys_window_struct.h"
 
-struct graphics_color {
-    uint8_t r;
-    uint8_t g;
-    uint8_t b;
-};
 
 int graphics_width();
 int graphics_height();

--- a/src/process.c
+++ b/src/process.c
@@ -75,6 +75,8 @@ struct process *process_create(unsigned code_size, unsigned stack_size) {
 
     process_stack_init(p);
 
+    p->window = 0;
+
     return p;
 }
 

--- a/src/process.h
+++ b/src/process.h
@@ -28,6 +28,7 @@ struct process {
     char *kstack_top;
     char *stack_ptr;
     uint32_t entry;
+    struct window *window;
 };
 
 void process_init();

--- a/src/sys_window.h
+++ b/src/sys_window.h
@@ -1,0 +1,128 @@
+/*
+Copyright (C) 2016 The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file LICENSE for details.
+*/
+
+#ifndef SYS_WINDOW_H
+#define SYS_WINDOW_H
+
+#include "sys_window_struct.h"
+
+/**
+ * @brief A struct to hold information needed to draw an arc
+ * @details This struct holds data that can be passed to draw_arc
+ * to indicate the radius and start/end angles. This information
+ * is collected here as alone, draw_arc would need more parameters
+ * than are available to system calls
+ */
+struct arc_info {
+	double r;
+	double start_theta;
+	double end_theta;
+};
+
+// Window System Calls
+
+/**
+ * @brief Creates a window for the process
+ * @details Invokes the window_create function with given parameters and assigns
+ * the resulting window to calling process
+ * 
+ * @param x The x position of the window, relative to its parent
+ * @param y The y position of the window, relative to its parent
+ * @param width The width of the window
+ * @param height The height of the window
+ * @return 0 if a window was created, -1 if the process already has a widnow, otherwise error
+ */
+static inline int32_t create_window(int x, int y, uint32_t width, uint32_t height) {
+	return syscall(SYSCALL_window_create, x, y, width, height, 0);
+}
+
+/**
+ * @brief Sets the border color of the process' window
+ * @details Invokes the window_set_border_color function to change window color
+ * 
+ * @param graphics_color The color to set the border to
+ * @return 0 on success, or -1 if the calling process has no window
+ */
+static inline int32_t set_border_color(const struct graphics_color *border_color) {
+	return syscall(SYSCALL_window_set_border_color, (int)border_color, 0, 0, 0, 0);
+}
+
+/**
+ * @brief Draws a line in the current process' window
+ * @details Invokes the window_draw_line function to draw into the current window
+ * 
+ * @param x1 The x position of the first point in the line
+ * @param y1 The y position of the first point in the line
+ * @param x2 The x position of the second point in the line
+ * @param y2 The y position of the second point in the line
+ * @param color The color of the line
+ * @return 0 on success, or -1 if the calling process has no window
+ */
+static inline int32_t draw_line(int x1, int y1, int x2, int y2, const struct graphics_color *color) {
+	return syscall(SYSCALL_window_draw_line, x1, y1, x2, y2, (int)color);
+}
+
+/**
+ * @brief Draws an arc in the current process' window
+ * @details Invokes the window_draw_arc function to draw into the current window
+ * 
+ * @param x The x position of the center of the arc
+ * @param y The y position of the center of the arc
+ * @param arc The arc_info describing the arc length and radius
+ * @param color The color to draw in
+ * @return 0 on success, or -1 if the calling process has no window
+ */
+static inline int32_t draw_arc(int x, int y, const struct arc_info *arc, const struct graphics_color *c) {
+	return syscall(SYSCALL_window_draw_arc, x, y, (int)arc, (int)c, 0);
+}
+
+/**
+ * @brief Draws a circle in the current process' window
+ * @details Invokes the window_draw_circle function to draw into the current window
+ * 
+ * @param x The x position of the center of the circle, relative to the window
+ * @param y The y position of the center of the circle, relative to the window
+ * @param r The radius of the circle
+ * @param c The color to draw in
+ * @return 0 on success, or -1 if the calling process has no window
+ */
+static inline int32_t draw_circle(int x, int y, const double *r, const struct graphics_color *c) {
+	return syscall(SYSCALL_window_draw_circle, x, y, (int)r, (int)c, 0);
+}
+
+/**
+ * @brief Draws a character in the current process' window
+ * @details Invokes the window_draw_char function to draw into the current window
+ * 
+ * @param x The x position of the top left corner of the char
+ * @param y The y position of the top left corner of the char
+ * @param c The character to draw
+ * @param fgcolor The color to draw the character
+ * @param bgcolor The color to draw the negative space
+ * @return 0 on success, or -1 if the calling process has no window
+ */
+static inline int32_t draw_char(int x, int y, char c, const struct graphics_color *fgcolor, const struct graphics_color *bgcolor) {
+	return syscall(SYSCALL_window_draw_char, x, y, c, (int)fgcolor, (int)bgcolor);
+}
+
+/**
+ * @brief Draws a string in the current process' window
+ * @details Invokes the window_draw_string function to draw into the current window
+ * 
+ * @param x The x position of the top left corner of the first character
+ * @param y The y position of the top right corner of the first character
+ * @param str The text to be drawn, null terminated
+ * @param fgcolor The color to draw the characters
+ * @param bgcolor The color to draw the negative space
+ * @return 0 on success, or -1 if the calling process has no window
+ */
+static inline int32_t draw_string(int x, int y, const char *str, const struct graphics_color *fgcolor,
+	const struct graphics_color *bgcolor) {
+	return syscall(SYSCALL_window_draw_string, x, y, (int)str, (int)fgcolor, (int)bgcolor);
+}
+
+
+#endif

--- a/src/sys_window_struct.h
+++ b/src/sys_window_struct.h
@@ -1,0 +1,16 @@
+/*
+Copyright (C) 2016 The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file LICENSE for details.
+*/
+
+#ifndef SYS_WINDOW_STRUCT_H
+#define SYS_WINDOW_STRUCT_H
+
+struct graphics_color {
+    uint8_t r;
+    uint8_t g;
+    uint8_t b;
+};
+
+#endif

--- a/src/syscall.h
+++ b/src/syscall.h
@@ -8,7 +8,6 @@ See the file LICENSE for details.
 #define SYSCALL_H
 
 #include "kerneltypes.h"
-#include "graphics.h"
 
 #define SYSCALL_exit     1
 #define SYSCALL_testcall 2
@@ -25,19 +24,6 @@ See the file LICENSE for details.
 uint32_t syscall(uint32_t n, uint32_t a, uint32_t b, uint32_t c, uint32_t d,
                  uint32_t e);
 
-/**
- * @brief A struct to hold information needed to draw an arc
- * @details This struct holds data that can be passed to draw_arc
- * to indicate the radius and start/end angles. This information
- * is collected here as alone, draw_arc would need more parameters
- * than are available to system calls
- */
-struct arc_info {
-	double r;
-	double start_theta;
-	double end_theta;
-};
-
 static inline int32_t exit(uint32_t status) {
     return syscall(SYSCALL_exit, status, 0, 0, 0, 0);
 }
@@ -50,108 +36,8 @@ static inline int32_t yield() {
     return syscall(SYSCALL_yield, 0, 0, 0, 0, 0);
 }
 
-// Window System Calls
+// MARK Module System call includes
 
-/**
- * @brief Creates a window for the process
- * @details Invokes the window_create function with given parameters and assigns
- * the resulting window to calling process
- * 
- * @param x The x position of the window, relative to its parent
- * @param y The y position of the window, relative to its parent
- * @param width The width of the window
- * @param height The height of the window
- * @return 0 if a window was created, otherwise error
- */
-static inline int32_t create_window(int x, int y, uint32_t width, uint32_t height) {
-	return syscall(SYSCALL_window_create, x, y, width, height, 0);
-}
-
-/**
- * @brief Sets the border color of the process' window
- * @details Invokes the window_set_border_color function to change window color
- * 
- * @param graphics_color The color to set the border to
- * @return 0 on success, or -1 if the calling process has no window
- */
-static inline int32_t set_border_color(const struct graphics_color *border_color) {
-	return syscall(SYSCALL_window_set_border_color, (int)border_color, 0, 0, 0, 0);
-}
-
-/**
- * @brief Draws a line in the current process' window
- * @details Invokes the window_draw_line function to draw into the current window
- * 
- * @param x1 The x position of the first point in the line
- * @param y1 The y position of the first point in the line
- * @param x2 The x position of the second point in the line
- * @param y2 The y position of the second point in the line
- * @param color The color of the line
- * @return 0 on success, or -1 if the calling process has no window
- */
-static inline int32_t draw_line(int x1, int y1, int x2, int y2, const struct graphics_color *color) {
-	return syscall(SYSCALL_window_draw_line, x1, y1, x2, y2, (int)color);
-}
-
-/**
- * @brief Draws an arc in the current process' window
- * @details Invokes the window_draw_arc function to draw into the current window
- * 
- * @param x The x position of the center of the arc
- * @param y The y position of the center of the arc
- * @param r The radius of the arc
- * @param start_theta The starting angle of the arc, between 0 and 2*PI. See sin/cos
- * @param end_theta The ending angle of the arc, between 0 and 2*PI. See sin/cos
- * @param color The color to draw in
- * @return 0 on success, or -1 if the calling process has no window
- */
-static inline int32_t draw_arc(int x, int y, const struct arc_info *arc, const struct graphics_color *c) {
-	return syscall(SYSCALL_window_draw_arc, x, y, (int)arc, (int)c, 0);
-}
-
-/**
- * @brief Draws a circle in the current process' window
- * @details Invokes the window_draw_circle function to draw into the current window
- * 
- * @param x The x position of the center of the circle, relative to the window
- * @param y The y position of the center of the circle, relative to the window
- * @param r The radius of the circle
- * @param color The color to draw in
- * @return 0 on success, or -1 if the calling process has no window
- */
-static inline int32_t draw_circle(int x, int y, const double *r, const struct graphics_color *c) {
-	return syscall(SYSCALL_window_draw_circle, x, y, (int)r, (int)c, 0);
-}
-
-/**
- * @brief Draws a character in the current process' window
- * @details Invokes the window_draw_char function to draw into the current window
- * 
- * @param x The x position of the top left corner of the char
- * @param y The y position of the top left corner of the char
- * @param ch The character to draw
- * @param fgcolor The color to draw the character
- * @param bgcolor The color to draw the negative space
- * @return 0 on success, or -1 if the calling process has no window
- */
-static inline int32_t draw_char(int x, int y, char c, const struct graphics_color *fgcolor, const struct graphics_color *bgcolor) {
-	return syscall(SYSCALL_window_draw_char, x, y, c, (int)fgcolor, (int)bgcolor);
-}
-
-/**
- * @brief Draws a string in the current process' window
- * @details Invokes the window_draw_string function to draw into the current window
- * 
- * @param x The x position of the top left corner of the first character
- * @param y The y position of the top right corner of the first character
- * @param str The text to be drawn, null terminated
- * @param graphics_color The color to draw the characters
- * @param graphics_color The color to draw the negative space
- * @return 0 on success, or -1 if the calling process has no window
- */
-static inline int32_t draw_string(int x, int y, const char *str, const struct graphics_color *fgcolor,
-	const struct graphics_color *bgcolor) {
-	return syscall(SYSCALL_window_draw_string, x, y, (int)str, (int)fgcolor, (int)bgcolor);
-}
+#include "sys_window.h"
 
 #endif

--- a/src/syscall.h
+++ b/src/syscall.h
@@ -8,13 +8,35 @@ See the file LICENSE for details.
 #define SYSCALL_H
 
 #include "kerneltypes.h"
+#include "graphics.h"
 
 #define SYSCALL_exit     1
 #define SYSCALL_testcall 2
 #define SYSCALL_yield    3
 
+#define SYSCALL_window_create 200
+#define SYSCALL_window_set_border_color 201
+#define SYSCALL_window_draw_line 202
+#define SYSCALL_window_draw_arc 203
+#define SYSCALL_window_draw_circle 204
+#define SYSCALL_window_draw_char 205
+#define SYSCALL_window_draw_string 206
+
 uint32_t syscall(uint32_t n, uint32_t a, uint32_t b, uint32_t c, uint32_t d,
                  uint32_t e);
+
+/**
+ * @brief A struct to hold information needed to draw an arc
+ * @details This struct holds data that can be passed to draw_arc
+ * to indicate the radius and start/end angles. This information
+ * is collected here as alone, draw_arc would need more parameters
+ * than are available to system calls
+ */
+struct arc_info {
+	double r;
+	double start_theta;
+	double end_theta;
+};
 
 static inline int32_t exit(uint32_t status) {
     return syscall(SYSCALL_exit, status, 0, 0, 0, 0);
@@ -26,6 +48,110 @@ static inline int32_t testcall(int x) {
 
 static inline int32_t yield() {
     return syscall(SYSCALL_yield, 0, 0, 0, 0, 0);
+}
+
+// Window System Calls
+
+/**
+ * @brief Creates a window for the process
+ * @details Invokes the window_create function with given parameters and assigns
+ * the resulting window to calling process
+ * 
+ * @param x The x position of the window, relative to its parent
+ * @param y The y position of the window, relative to its parent
+ * @param width The width of the window
+ * @param height The height of the window
+ * @return 0 if a window was created, otherwise error
+ */
+static inline int32_t create_window(int x, int y, uint32_t width, uint32_t height) {
+	return syscall(SYSCALL_window_create, x, y, width, height, 0);
+}
+
+/**
+ * @brief Sets the border color of the process' window
+ * @details Invokes the window_set_border_color function to change window color
+ * 
+ * @param graphics_color The color to set the border to
+ * @return 0 on success, or -1 if the calling process has no window
+ */
+static inline int32_t set_border_color(const struct graphics_color *border_color) {
+	return syscall(SYSCALL_window_set_border_color, (int)border_color, 0, 0, 0, 0);
+}
+
+/**
+ * @brief Draws a line in the current process' window
+ * @details Invokes the window_draw_line function to draw into the current window
+ * 
+ * @param x1 The x position of the first point in the line
+ * @param y1 The y position of the first point in the line
+ * @param x2 The x position of the second point in the line
+ * @param y2 The y position of the second point in the line
+ * @param color The color of the line
+ * @return 0 on success, or -1 if the calling process has no window
+ */
+static inline int32_t draw_line(int x1, int y1, int x2, int y2, const struct graphics_color *color) {
+	return syscall(SYSCALL_window_draw_line, x1, y1, x2, y2, (int)color);
+}
+
+/**
+ * @brief Draws an arc in the current process' window
+ * @details Invokes the window_draw_arc function to draw into the current window
+ * 
+ * @param x The x position of the center of the arc
+ * @param y The y position of the center of the arc
+ * @param r The radius of the arc
+ * @param start_theta The starting angle of the arc, between 0 and 2*PI. See sin/cos
+ * @param end_theta The ending angle of the arc, between 0 and 2*PI. See sin/cos
+ * @param color The color to draw in
+ * @return 0 on success, or -1 if the calling process has no window
+ */
+static inline int32_t draw_arc(int x, int y, const struct arc_info *arc, const struct graphics_color *c) {
+	return syscall(SYSCALL_window_draw_arc, x, y, (int)arc, (int)c, 0);
+}
+
+/**
+ * @brief Draws a circle in the current process' window
+ * @details Invokes the window_draw_circle function to draw into the current window
+ * 
+ * @param x The x position of the center of the circle, relative to the window
+ * @param y The y position of the center of the circle, relative to the window
+ * @param r The radius of the circle
+ * @param color The color to draw in
+ * @return 0 on success, or -1 if the calling process has no window
+ */
+static inline int32_t draw_circle(int x, int y, const double *r, const struct graphics_color *c) {
+	return syscall(SYSCALL_window_draw_circle, x, y, (int)r, (int)c, 0);
+}
+
+/**
+ * @brief Draws a character in the current process' window
+ * @details Invokes the window_draw_char function to draw into the current window
+ * 
+ * @param x The x position of the top left corner of the char
+ * @param y The y position of the top left corner of the char
+ * @param ch The character to draw
+ * @param fgcolor The color to draw the character
+ * @param bgcolor The color to draw the negative space
+ * @return 0 on success, or -1 if the calling process has no window
+ */
+static inline int32_t draw_char(int x, int y, char c, const struct graphics_color *fgcolor, const struct graphics_color *bgcolor) {
+	return syscall(SYSCALL_window_draw_char, x, y, c, (int)fgcolor, (int)bgcolor);
+}
+
+/**
+ * @brief Draws a string in the current process' window
+ * @details Invokes the window_draw_string function to draw into the current window
+ * 
+ * @param x The x position of the top left corner of the first character
+ * @param y The y position of the top right corner of the first character
+ * @param str The text to be drawn, null terminated
+ * @param graphics_color The color to draw the characters
+ * @param graphics_color The color to draw the negative space
+ * @return 0 on success, or -1 if the calling process has no window
+ */
+static inline int32_t draw_string(int x, int y, const char *str, const struct graphics_color *fgcolor,
+	const struct graphics_color *bgcolor) {
+	return syscall(SYSCALL_window_draw_string, x, y, (int)str, (int)fgcolor, (int)bgcolor);
 }
 
 #endif

--- a/src/syscall_handler.c
+++ b/src/syscall_handler.c
@@ -7,6 +7,9 @@ See the file LICENSE for details.
 #include "syscall.h"
 #include "console.h"
 #include "process.h"
+#include "window.h"
+
+#define CHECK_PROC_WINDOW() if(current->window == 0) return -1
 
 uint32_t sys_exit(uint32_t code) {
     process_exit(code);
@@ -23,6 +26,50 @@ uint32_t sys_testcall(uint32_t code) {
     return 0;
 }
 
+int32_t sys_window_create(int x, int y, int width, int height) {
+    CHECK_PROC_WINDOW();
+    struct window *win = window_create(x, y, width, height, 0);
+    current->window = win;
+    return win != 0;
+}
+
+int32_t sys_set_border_color(const struct graphics_color *color) {
+    CHECK_PROC_WINDOW();
+    window_set_border_color(current->window, *color);
+    return 0;
+}
+
+int32_t sys_draw_line(int x1, int y1, int x2, int y2, const struct graphics_color *color) {
+    CHECK_PROC_WINDOW();
+    window_draw_line(current->window, x1, y1, x2, y2, *color);
+    return 0;
+}
+
+int32_t sys_draw_arc(int x, int y, const struct arc_info *arc, const struct graphics_color *color) {
+    CHECK_PROC_WINDOW();
+    window_draw_arc(current->window, x, y, arc->r, arc->start_theta, arc->end_theta, *color);
+    return 0;
+}
+
+int32_t sys_draw_circle(int x, int y, const double *r, const struct graphics_color *color) {
+    CHECK_PROC_WINDOW();
+    window_draw_circle(current->window, x, y, *r, *color);
+    return 0;
+}
+
+int32_t sys_draw_char(int x, int y, char c, const struct graphics_color *fgcolor, const struct graphics_color *bgcolor) {
+    CHECK_PROC_WINDOW();
+    window_draw_char(current->window, x, y, c, *fgcolor, *bgcolor);
+    return 0;
+}
+
+int32_t sys_draw_string(int x, int y, const char *str, const struct graphics_color *fgcolor,
+    const struct graphics_color *bgcolor) {
+    CHECK_PROC_WINDOW();
+    window_draw_string(current->window, x, y, str, *fgcolor, *bgcolor);
+    return 0;
+}
+
 int32_t syscall_handler(uint32_t n, uint32_t a, uint32_t b, uint32_t c,
                         uint32_t d, uint32_t e) {
     switch (n) {
@@ -32,6 +79,20 @@ int32_t syscall_handler(uint32_t n, uint32_t a, uint32_t b, uint32_t c,
             return sys_testcall(a);
         case SYSCALL_yield:
             return sys_yield();
+        case SYSCALL_window_create:
+            return sys_window_create(a, b, c, d);
+        case SYSCALL_window_set_border_color:
+            return sys_set_border_color((const struct graphics_color *)a);
+        case SYSCALL_window_draw_line:
+            return sys_draw_line(a, b, c, d, (const struct graphics_color *)e);
+        case SYSCALL_window_draw_arc:
+            return sys_draw_arc(a, b, (const struct arc_info *)c, (const struct graphics_color *)d);
+        case SYSCALL_window_draw_circle:
+            return sys_draw_circle(a, b, (const double *)c, (const struct graphics_color *)d);
+        case SYSCALL_window_draw_char:
+            return sys_draw_char(a, b, (char)c, (const struct graphics_color *)d, (const struct graphics_color *)e);
+        case SYSCALL_window_draw_string:
+            return sys_draw_string(a, b, (const char *)c, (const struct graphics_color *)d, (const struct graphics_color *)e);
         default:
             return -1;
     }

--- a/src/syscall_handler.c
+++ b/src/syscall_handler.c
@@ -7,9 +7,8 @@ See the file LICENSE for details.
 #include "syscall.h"
 #include "console.h"
 #include "process.h"
-#include "window.h"
+#include "syscall_handler_window.h"
 
-#define CHECK_PROC_WINDOW() if(current->window == 0) return -1
 
 uint32_t sys_exit(uint32_t code) {
     process_exit(code);
@@ -23,50 +22,6 @@ uint32_t sys_yield() {
 
 uint32_t sys_testcall(uint32_t code) {
     console_printf("testing: %d\n", code);
-    return 0;
-}
-
-int32_t sys_window_create(int x, int y, int width, int height) {
-    CHECK_PROC_WINDOW();
-    struct window *win = window_create(x, y, width, height, 0);
-    current->window = win;
-    return win != 0;
-}
-
-int32_t sys_set_border_color(const struct graphics_color *color) {
-    CHECK_PROC_WINDOW();
-    window_set_border_color(current->window, *color);
-    return 0;
-}
-
-int32_t sys_draw_line(int x1, int y1, int x2, int y2, const struct graphics_color *color) {
-    CHECK_PROC_WINDOW();
-    window_draw_line(current->window, x1, y1, x2, y2, *color);
-    return 0;
-}
-
-int32_t sys_draw_arc(int x, int y, const struct arc_info *arc, const struct graphics_color *color) {
-    CHECK_PROC_WINDOW();
-    window_draw_arc(current->window, x, y, arc->r, arc->start_theta, arc->end_theta, *color);
-    return 0;
-}
-
-int32_t sys_draw_circle(int x, int y, const double *r, const struct graphics_color *color) {
-    CHECK_PROC_WINDOW();
-    window_draw_circle(current->window, x, y, *r, *color);
-    return 0;
-}
-
-int32_t sys_draw_char(int x, int y, char c, const struct graphics_color *fgcolor, const struct graphics_color *bgcolor) {
-    CHECK_PROC_WINDOW();
-    window_draw_char(current->window, x, y, c, *fgcolor, *bgcolor);
-    return 0;
-}
-
-int32_t sys_draw_string(int x, int y, const char *str, const struct graphics_color *fgcolor,
-    const struct graphics_color *bgcolor) {
-    CHECK_PROC_WINDOW();
-    window_draw_string(current->window, x, y, str, *fgcolor, *bgcolor);
     return 0;
 }
 

--- a/src/syscall_handler_window.c
+++ b/src/syscall_handler_window.c
@@ -1,0 +1,55 @@
+/*
+Copyright (C) 2016 The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file LICENSE for details.
+*/
+#include "syscall_handler_window.h"
+#include "process.h"
+
+#define CHECK_PROC_WINDOW() if(current->window == 0) return -1
+
+int32_t sys_window_create(int x, int y, int width, int height) {
+    if (current->window != 0) {
+        return -1;
+    }
+    struct window *win = window_create(x, y, width, height, 0);
+    current->window = win;
+    return win != 0;
+}
+
+int32_t sys_set_border_color(const struct graphics_color *color) {
+    CHECK_PROC_WINDOW();
+    window_set_border_color(current->window, *color);
+    return 0;
+}
+
+int32_t sys_draw_line(int x1, int y1, int x2, int y2, const struct graphics_color *color) {
+    CHECK_PROC_WINDOW();
+    window_draw_line(current->window, x1, y1, x2, y2, *color);
+    return 0;
+}
+
+int32_t sys_draw_arc(int x, int y, const struct arc_info *arc, const struct graphics_color *color) {
+    CHECK_PROC_WINDOW();
+    window_draw_arc(current->window, x, y, arc->r, arc->start_theta, arc->end_theta, *color);
+    return 0;
+}
+
+int32_t sys_draw_circle(int x, int y, const double *r, const struct graphics_color *color) {
+    CHECK_PROC_WINDOW();
+    window_draw_circle(current->window, x, y, *r, *color);
+    return 0;
+}
+
+int32_t sys_draw_char(int x, int y, char c, const struct graphics_color *fgcolor, const struct graphics_color *bgcolor) {
+    CHECK_PROC_WINDOW();
+    window_draw_char(current->window, x, y, c, *fgcolor, *bgcolor);
+    return 0;
+}
+
+int32_t sys_draw_string(int x, int y, const char *str, const struct graphics_color *fgcolor,
+    const struct graphics_color *bgcolor) {
+    CHECK_PROC_WINDOW();
+    window_draw_string(current->window, x, y, str, *fgcolor, *bgcolor);
+    return 0;
+}

--- a/src/syscall_handler_window.h
+++ b/src/syscall_handler_window.h
@@ -1,0 +1,28 @@
+/*
+Copyright (C) 2016 The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file LICENSE for details.
+*/
+
+#ifndef SYSCALL_HANDLER_WINDOW_H
+#define SYSCALL_HANDLER_WINDOW_H
+
+#include "window.h"
+#include "syscall.h"
+
+int32_t sys_window_create(int x, int y, int width, int height);
+
+int32_t sys_set_border_color(const struct graphics_color *color);
+
+int32_t sys_draw_line(int x1, int y1, int x2, int y2, const struct graphics_color *color);
+
+int32_t sys_draw_arc(int x, int y, const struct arc_info *arc, const struct graphics_color *color);
+
+int32_t sys_draw_circle(int x, int y, const double *r, const struct graphics_color *color);
+
+int32_t sys_draw_char(int x, int y, char c, const struct graphics_color *fgcolor, const struct graphics_color *bgcolor);
+
+int32_t sys_draw_string(int x, int y, const char *str, const struct graphics_color *fgcolor,
+    const struct graphics_color *bgcolor);
+
+#endif


### PR DESCRIPTION
This adds a preliminary set of window system calls. All drawing is done
in the current process' window. If there is no window for the calling
process, then no draw calls will occur and an error will be returned.

Tested by creating a process based on the runproc example and drawing
