### PR TITLE
[NUN-20] Fix Caps Lock Holds Down Shift

### DIFF
--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -95,9 +95,19 @@ static char keyboard_map(int code) {
             return KEY_INVALID;
         } else if (shiftlock_mode) {
             if (shift_mode) {
-                return keymap[code].normal;
+                if (keymap[code].normal >= 97 && keymap[code].normal <= 122) {
+                    return keymap[code].normal;
+                }
+                else {
+                    return keymap[code].shifted;
+                }
             } else {
-                return keymap[code].shifted;
+                if (keymap[code].normal >= 97 && keymap[code].normal <= 122) {
+                    return keymap[code].shifted;
+                }
+                else {
+                    return keymap[code].normal;
+                }
             }
         } else if (shift_mode) {
             return keymap[code].shifted;


### PR DESCRIPTION
Caps lock only capitalizes characters. Caps lock does not modify any
other type of key. To modify other characters, you must hold down shift.
