### PR TITLE
[NUN-31] Fix No 'W' Printing Bug

### DIFF
--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -12,9 +12,7 @@ See the file LICENSE for details.
 #include "kernelcore.h"
 #include "ps2.h"
 
-#define KEY_INVALID 0127
-
-#define W_SUBSTITUTE -1
+#define KEY_INVALID 0036
 
 #define SPECIAL_SHIFT 1
 #define SPECIAL_ALT   2
@@ -105,24 +103,14 @@ static char keyboard_map(int code) {
                 }
             } else {
                 if (keymap[code].normal >= 97 && keymap[code].normal <= 122) {
-                    if (keymap[code].shifted == 87) {
-                        return W_SUBSTITUTE;
-                    }
-                    else {
-                        return keymap[code].shifted;
-                    }
+                    return keymap[code].shifted;
                 }
                 else {
                     return keymap[code].normal;
                 }
             }
         } else if (shift_mode) {
-            if (keymap[code].shifted == 87) {
-                return W_SUBSTITUTE;
-            }
-            else {
-                return keymap[code].shifted;
-            }
+            return keymap[code].shifted;
         } else if (ctrl_mode) {
             return keymap[code].ctrled;
         } else {
@@ -136,13 +124,11 @@ static char keyboard_map(int code) {
 void keyboard_interrupt(int i, int code) {
     char c;
     c = keyboard_map(keyboard_scan());
+
     if (c == KEY_INVALID) {
         return;
     }
 
-    if (c == W_SUBSTITUTE) {
-        c = ASCII_W;
-    }
     if ((buffer_write + 1) == (buffer_read % KEYBOARD_BUFFER_SIZE)) {
         return;
     }

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -14,6 +14,8 @@ See the file LICENSE for details.
 
 #define KEY_INVALID 0127
 
+#define W_SUBSTITUTE -1
+
 #define SPECIAL_SHIFT 1
 #define SPECIAL_ALT   2
 #define SPECIAL_CTRL  3
@@ -103,14 +105,24 @@ static char keyboard_map(int code) {
                 }
             } else {
                 if (keymap[code].normal >= 97 && keymap[code].normal <= 122) {
-                    return keymap[code].shifted;
+                    if (keymap[code].shifted == 87) {
+                        return W_SUBSTITUTE;
+                    }
+                    else {
+                        return keymap[code].shifted;
+                    }
                 }
                 else {
                     return keymap[code].normal;
                 }
             }
         } else if (shift_mode) {
-            return keymap[code].shifted;
+            if (keymap[code].shifted == 87) {
+                return W_SUBSTITUTE;
+            }
+            else {
+                return keymap[code].shifted;
+            }
         } else if (ctrl_mode) {
             return keymap[code].ctrled;
         } else {
@@ -126,6 +138,10 @@ void keyboard_interrupt(int i, int code) {
     c = keyboard_map(keyboard_scan());
     if (c == KEY_INVALID) {
         return;
+    }
+
+    if (c == W_SUBSTITUTE) {
+        c = ASCII_W;
     }
     if ((buffer_write + 1) == (buffer_read % KEYBOARD_BUFFER_SIZE)) {
         return;


### PR DESCRIPTION
Fixes the inability to print the 'W' character. This was caused by the constant KEY_INVALID stomping on the ASCII value of 'W' which is 87. Fixed by assigning 'W' a temporary unique value and then handling that value later.
Tested by successfully printing all characters.
