### PR TITLE
Window events

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -10,7 +10,7 @@ MEMORY_OBJS = memory_raw.o kmalloc.o
 TEST_OBJS = module_tests.o testing.o tests.o
 DEBUG_OBJS = debug_kernel.o
 FS_OBJS = fs.o syscall_handler_fs.o
-WINDOW_OBJS = window.o graphics.o syscall_handler_window.o
+WINDOW_OBJS = window.o graphics.o syscall_handler_window.o window_manager.o
 PROCESS_OBJS = syscall_handler_process.o syscall_handler_permissions.o process.o permissions_capabilities.o
 
 BINARIES = bin/test_userproc_even.nun

--- a/src/Makefile
+++ b/src/Makefile
@@ -13,7 +13,7 @@ FS_OBJS = fs.o syscall_handler_fs.o
 WINDOW_OBJS = window.o graphics.o syscall_handler_window.o window_manager.o
 PROCESS_OBJS = syscall_handler_process.o syscall_handler_permissions.o process.o permissions_capabilities.o
 
-BINARIES = bin/test_userproc_even.nun
+BINARIES = bin/test_userproc_even.nun bin/test_window.nun
 LIB_INCLUDE_PATH = ./include
 
 KERNEL_CCFLAGS = -Wall -c -ffreestanding -m32 -march=i386

--- a/src/bin/test_window.c
+++ b/src/bin/test_window.c
@@ -1,0 +1,27 @@
+int main();
+int _start() {
+    return main();
+
+    // invoke system call that kills the process
+}
+
+#include "syscall.h"
+
+int main() {
+    create_window(10, 10, 400, 400);
+    struct graphics_color c = {0,255,0};
+    struct graphics_color bg = {0,0,0};
+    struct event e;
+    int x = 0;
+    while (1) {
+        int res = get_event(&e);
+        if (res == 0) {
+            if (e.type == EVENT_KEYBOARD_PRESS) {
+                draw_char(x, 0, e.character, &c, &bg);
+                x += 10;
+            }
+        }
+    }
+
+    return 0;
+}

--- a/src/cmd_line.c
+++ b/src/cmd_line.c
@@ -59,7 +59,9 @@ void cmd_line_attempt(const char *line) {
         cmd_line_help(the_rest);
     } else if (strcmp("window_test", first_word) == 0) {
         console_printf("\f");
-        window_hierarchy_test();
+        uint32_t identifier = permissions_capability_create();
+        run("/BIN/TEST_WIN.NUN", identifier);   
+        permissions_capability_delete(identifier);
     }
     /*else if () {
      *...

--- a/src/include/syscall.h
+++ b/src/include/syscall.h
@@ -23,6 +23,7 @@ See the file LICENSE for details.
 #define SYSCALL_window_draw_circle 204
 #define SYSCALL_window_draw_char 205
 #define SYSCALL_window_draw_string 206
+#define SYSCALL_window_get_event 207
 
 #define SYSCALL_open     601
 #define SYSCALL_close    602

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -11,6 +11,7 @@ See the file LICENSE for details.
 #include "process.h"
 #include "kernelcore.h"
 #include "ps2.h"
+#include "window_manager.h"
 
 #define KEY_INVALID 0036
 
@@ -130,9 +131,16 @@ void keyboard_interrupt(int i, int code) {
     if ((buffer_write + 1) == (buffer_read % KEYBOARD_BUFFER_SIZE)) {
         return;
     }
-    buffer[buffer_write] = c;
-    buffer_write = (buffer_write + 1) % KEYBOARD_BUFFER_SIZE;
-    process_wakeup(&queue);
+    if (active_window) {
+        send_event_keyboard_press(c);
+    } else {
+        if ((buffer_write + 1) == (buffer_read % KEYBOARD_BUFFER_SIZE)) {
+            return;
+        }
+        buffer[buffer_write] = c;
+        buffer_write = (buffer_write + 1) % KEYBOARD_BUFFER_SIZE;
+        process_wakeup(&queue);
+    }
 }
 
 char keyboard_read() {

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -128,9 +128,6 @@ void keyboard_interrupt(int i, int code) {
         return;
     }
 
-    if ((buffer_write + 1) == (buffer_read % KEYBOARD_BUFFER_SIZE)) {
-        return;
-    }
     if (active_window) {
         send_event_keyboard_press(c);
     } else {

--- a/src/mouse.c
+++ b/src/mouse.c
@@ -11,6 +11,7 @@
 #include "ioports.h"
 #include "graphics.h"
 #include "console.h"
+#include "window_manager.h"
 
 static uint8_t mouse_cycle = 0;
 static uint8_t mouse_byte[3];
@@ -125,6 +126,9 @@ void mouse_interrupt() {
             mouse_cycle = 0;
             if (mouse_enabled && mouse_map()) {
                 graphics_mouse();
+                //TODO: Filter out mouse events that happen
+                // outside the current window
+                send_event_mouse_move();
             }
             break;
     }

--- a/src/sys_window.h
+++ b/src/sys_window.h
@@ -124,8 +124,16 @@ static inline int32_t draw_string(int x, int y, const char *str, const struct gr
 	return syscall(SYSCALL_window_draw_string, x, y, (int)str, (int)fgcolor, (int)bgcolor);
 }
 
+/**
+ * @brief Get the event at the front of the event queue
+ * @details This will check if there is an event in the event queue
+ * for this window, and if so it will fill e with that information
+ * 
+ * @param e An event struct to be filled with information of the event
+ * @return 0 if an event was found and filled, 2 if there is no waiting event
+ */
 static inline int32_t get_event(struct event *e) {
-	return syscall(SYSCALL_window_get_event, (int)e, 0, 0, 0, 0);
+	return syscall(SYSCALL_window_get_event, (uint32_t)e, 0, 0, 0, 0);
 }
 
 #endif

--- a/src/sys_window.h
+++ b/src/sys_window.h
@@ -124,5 +124,8 @@ static inline int32_t draw_string(int x, int y, const char *str, const struct gr
 	return syscall(SYSCALL_window_draw_string, x, y, (int)str, (int)fgcolor, (int)bgcolor);
 }
 
+static inline int32_t get_event(struct event *e) {
+	return syscall(SYSCALL_window_get_event, (int)e, 0, 0, 0, 0);
+}
 
 #endif

--- a/src/sys_window_struct.h
+++ b/src/sys_window_struct.h
@@ -7,10 +7,39 @@ See the file LICENSE for details.
 #ifndef SYS_WINDOW_STRUCT_H
 #define SYS_WINDOW_STRUCT_H
 
+#include "kerneltypes.h"
+#include "list.h"
+
 struct graphics_color {
     uint8_t r;
     uint8_t g;
     uint8_t b;
+};
+
+/**
+ * Defines possible types of events that the system
+ * can recieve
+ */
+typedef enum event_type {
+	EVENT_MOUSE_MOVE,
+	EVENT_MOUSE_CLICK,
+	EVENT_KEYBOARD_PRESS
+} event_type_t;
+
+/**
+ * @brief A window event
+ * @details This represents a single user input event,
+ * and tracks what type of event occured and the character
+ * that was typed, if it was a keyboard event
+ * 
+ * If the event was not a keyboard event, character will be
+ * the null terminator '\0' 
+ * 
+ */
+struct event {
+	struct list_node node;
+	event_type_t type;
+	char character;
 };
 
 #endif

--- a/src/syscall_handler.c
+++ b/src/syscall_handler.c
@@ -15,7 +15,6 @@ See the file LICENSE for details.
 #include "process.h"
 #include "syscall_handler_window.h"
 
-
 int32_t sys_debug_print(uint32_t a) {
     console_printf(" testing: %d\n", a);
     return 0;
@@ -57,6 +56,8 @@ int32_t syscall_handler(uint32_t n, uint32_t a, uint32_t b, uint32_t c,
             return sys_draw_char(a, b, (char)c, (const struct graphics_color *)d, (const struct graphics_color *)e);
         case SYSCALL_window_draw_string:
             return sys_draw_string(a, b, (const char *)c, (const struct graphics_color *)d, (const struct graphics_color *)e);
+        case SYSCALL_window_get_event:
+            return sys_get_event((struct event *)a);
         case SYSCALL_debug_print:
             return sys_debug_print(a); // for debugging
         default:

--- a/src/syscall_handler_window.c
+++ b/src/syscall_handler_window.c
@@ -5,6 +5,7 @@ See the file LICENSE for details.
 */
 #include "syscall_handler_window.h"
 #include "process.h"
+#include "string.h"
 
 #define CHECK_PROC_WINDOW() if(current->window == 0) return -1
 
@@ -51,5 +52,18 @@ int32_t sys_draw_string(int x, int y, const char *str, const struct graphics_col
     const struct graphics_color *bgcolor) {
     CHECK_PROC_WINDOW();
     window_draw_string(current->window, x, y, str, *fgcolor, *bgcolor);
+    return 0;
+}
+
+int32_t sys_get_event(struct event *e) {
+    CHECK_PROC_WINDOW();
+    struct list *list = &(current->window->event_queue);
+    struct event *last_event = (struct event *)list_pop_tail(list);
+    if (last_event == 0) {
+        return 2;
+    }
+
+    memcpy(e, last_event, sizeof(struct event));
+
     return 0;
 }

--- a/src/syscall_handler_window.h
+++ b/src/syscall_handler_window.h
@@ -8,6 +8,7 @@ See the file LICENSE for details.
 #define SYSCALL_HANDLER_WINDOW_H
 
 #include "window.h"
+#include "window_manager.h"
 #include "syscall.h"
 
 int32_t sys_window_create(int x, int y, int width, int height);
@@ -24,5 +25,7 @@ int32_t sys_draw_char(int x, int y, char c, const struct graphics_color *fgcolor
 
 int32_t sys_draw_string(int x, int y, const char *str, const struct graphics_color *fgcolor,
     const struct graphics_color *bgcolor);
+
+int32_t sys_get_event(struct event *e);
 
 #endif

--- a/src/window.c
+++ b/src/window.c
@@ -6,6 +6,7 @@ See the file LICENSE for details.
 
 #include "window.h"
 #include "memory.h"
+#include "window_manager.h"
 
 #define CHARACTER_W 8
 #define CHARACTER_H 8
@@ -60,10 +61,14 @@ struct window *window_create(int x, int y, int width, int height, struct window 
     w->width = width;
     w->height = height;
     w->parent = parent;
+    struct list l = {0, 0};
+    w->event_queue = l;
 
     // Draw the border
     struct graphics_color bc = {128,128,128};
     window_set_border_color(w, bc);
+
+    active_window = w;
 
     return w;
 }

--- a/src/window.h
+++ b/src/window.h
@@ -8,6 +8,7 @@ See the file LICENSE for details.
 #define WINDOW_H
 
 #include "graphics.h"
+#include "list.h"
 
 struct window {
     struct window *parent;
@@ -17,6 +18,7 @@ struct window {
     int height;
     struct graphics_color border_color;
     struct graphics_color background_color;
+    struct list event_queue;
 };
 
 /**

--- a/src/window_manager.c
+++ b/src/window_manager.c
@@ -1,0 +1,41 @@
+/*
+Copyright (C) 2016 The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file LICENSE for details.
+*/
+
+#include "window_manager.h"
+#include "kmalloc.h"
+#include "window.h"
+
+struct window *active_window = 0;
+
+static void send_event(struct event *e) {
+	if (!active_window || !e) {
+		return;
+	}
+
+	struct list *l = &(active_window->event_queue);
+	list_push_head(l, (struct list_node *)e);
+}
+
+void send_event_mouse_click() {
+	struct event *e = kmalloc(sizeof(struct event));
+	e->type = EVENT_MOUSE_CLICK;
+	e->character = '\0';
+	send_event(e);
+}
+
+void send_event_mouse_move() {
+	struct event *e = kmalloc(sizeof(struct event));
+	e->type = EVENT_MOUSE_MOVE;
+	e->character = '\0';
+	send_event(e);
+}
+
+void send_event_keyboard_press(char c) {
+	struct event *e = kmalloc(sizeof(struct event));
+	e->type = EVENT_KEYBOARD_PRESS;
+	e->character = c;
+	send_event(e);
+}

--- a/src/window_manager.h
+++ b/src/window_manager.h
@@ -9,10 +9,27 @@ See the file LICENSE for details.
 
 #include "sys_window_struct.h"
 
+/**
+ * @brief Posts a mouse click event
+ * @details Adds a mouse click event to the active window's
+ * event queue
+ */
 void send_event_mouse_click();
 
+/**
+ * @brief Post a mouse move event
+ * @details Adds a mouse move event to the active window's
+ * event queue
+ */
 void send_event_mouse_move();
 
+/**
+ * @brief Post a keyboard press event
+ * @details Adds a keyboard press event to the active window's
+ * event queue
+ * 
+ * @param c The character that was pressed
+ */
 void send_event_keyboard_press(char c);
 
 extern struct window *active_window;

--- a/src/window_manager.h
+++ b/src/window_manager.h
@@ -1,0 +1,46 @@
+/*
+Copyright (C) 2016 The University of Notre Dame
+This software is distributed under the GNU General Public License.
+See the file LICENSE for details.
+*/
+
+#ifndef WINDOW_MANAGER_H
+#define WINDOW_MANAGER_H
+
+#include "list.h"
+
+/**
+ * Defines possible types of events that the system
+ * can recieve
+ */
+typedef enum event_type {
+	EVENT_MOUSE_MOVE,
+	EVENT_MOUSE_CLICK,
+	EVENT_KEYBOARD_PRESS
+} event_type_t;
+
+/**
+ * @brief A window event
+ * @details This represents a single user input event,
+ * and tracks what type of event occured and the character
+ * that was typed, if it was a keyboard event
+ * 
+ * If the event was not a keyboard event, character will be
+ * the null terminator '\0' 
+ * 
+ */
+struct event {
+	struct list_node node;
+	event_type_t type;
+	char character;
+};
+
+void send_event_mouse_click();
+
+void send_event_mouse_move();
+
+void send_event_keyboard_press(char c);
+
+extern struct window *active_window;
+
+#endif

--- a/src/window_manager.h
+++ b/src/window_manager.h
@@ -7,33 +7,7 @@ See the file LICENSE for details.
 #ifndef WINDOW_MANAGER_H
 #define WINDOW_MANAGER_H
 
-#include "list.h"
-
-/**
- * Defines possible types of events that the system
- * can recieve
- */
-typedef enum event_type {
-	EVENT_MOUSE_MOVE,
-	EVENT_MOUSE_CLICK,
-	EVENT_KEYBOARD_PRESS
-} event_type_t;
-
-/**
- * @brief A window event
- * @details This represents a single user input event,
- * and tracks what type of event occured and the character
- * that was typed, if it was a keyboard event
- * 
- * If the event was not a keyboard event, character will be
- * the null terminator '\0' 
- * 
- */
-struct event {
-	struct list_node node;
-	event_type_t type;
-	char character;
-};
+#include "sys_window_struct.h"
 
 void send_event_mouse_click();
 


### PR DESCRIPTION
This adds a preliminary implementation of the event system for windows.
Events will be captured and added to an event queue for the active
window. The process can retrieve these events in the order that they
came in using the get_event system call. They provide a buffer into
which the event information should be copied.

If there is no active window, events will be distributed directly to
the kernel console.
