### PR TITLE
Handles fs_allowances during run() calls

### DIFF
--- a/src/fs.c
+++ b/src/fs.c
@@ -49,8 +49,6 @@ void fs_init_security(struct process *p) {
         p->fd_table[i].ptr = 0;
     }
 
-    p->files->num_open = 0;
-
     //Temporarily copy the entire list so that the in place checks work out
     fs_copy_allowances_list(&(p->fs_allowances_list), &(p->permissions->fs_allowances));
 

--- a/src/fs.c
+++ b/src/fs.c
@@ -45,13 +45,6 @@ void fs_init_security(struct process *p) {
     //Temporarily copy the entire list so that the in place checks work out
     fs_copy_allowances_list(&(p->fs_allowances_list), &(p->permissions->fs_allowances));
 
-//    //Allowances alloc'ing.
-//    struct fs_allowance *allowance = kmalloc(sizeof(*allowance));
-//    strcpy(allowance->path, "/");
-//    allowance->do_allow_below = 1;
-//
-//    //Set the lone permission in the list to root (that is all of the fs)
-//    list_push_head(&(p->fs_allowances_list), (struct list_node *)allowance);
 }
 
 // Look at the OS's table of open files to see if read write conflicts
@@ -319,6 +312,7 @@ int32_t fs_security_check(const char *path) {
     return 1;
 }
 
+// Copies one fs allowance to another piece by piece
 void copy_fs_allowance(struct fs_allowance *to, const struct fs_allowance *from) {
     to->do_allow_below = from->do_allow_below;
     strcpy(to->path, from->path);

--- a/src/fs.h
+++ b/src/fs.h
@@ -84,4 +84,22 @@ int32_t fs_write(const char *src, uint32_t bytes,  uint32_t fd);
  */
 void fs_init_security(struct process *p);
 
+/**
+ * @brief Copies a list of fs_allowances
+ * @details Allocates new space for each node and copies each node element for
+ * element
+ *
+ * @param to Pointer to the list to copy in to.
+ * @param from Pointer to the list to copy from.
+ */
+void fs_copy_allowances_list(struct list *to, struct list *from);
+
+/**
+ * @brief Frees allocated nodes of the list of allowances
+ * @details Iterates through the list and frees each dynamically allocated node
+ *
+ * @param to_free Pointer to the list to free
+ */
+void fs_free_allowances_list(struct list *to_free);
+
 #endif

--- a/src/fs.h
+++ b/src/fs.h
@@ -103,7 +103,7 @@ void fs_copy_allowances_list(struct list *to, struct list *from);
 void fs_free_allowances_list(struct list *to_free);
 
 /** 
-* @brief Initialize the open file table for the kernel
+ * @brief Initialize the open file table for the kernel
  * @details Initialize each fs_agnostic file to reflect an unopened file
  */
 void fs_sys_init_open_file_table();

--- a/src/permissions_capabilities.c
+++ b/src/permissions_capabilities.c
@@ -45,7 +45,6 @@ struct process_permissions *permissions_from_capability(struct permissions_capab
     new_permissions->offset_x = capability->offset_x;
     new_permissions->offset_y = capability->offset_y;
 
-    // copy allowances list into newly allocated memory
     struct list l = LIST_INIT;
     new_permissions->fs_allowances = l;
     fs_copy_allowances_list(&(new_permissions->fs_allowances), &(capability->fs_allowances));

--- a/src/permissions_capabilities.h
+++ b/src/permissions_capabilities.h
@@ -24,6 +24,7 @@ struct permissions_capability {
     int max_height;
     int offset_x;
     int offset_y;
+    struct list fs_allowances;
 };
 
 /**

--- a/src/process.h
+++ b/src/process.h
@@ -29,6 +29,7 @@ struct process_permissions {
     int max_height;
     int offset_x;
     int offset_y;
+    struct list fs_allowances;
 };
 
 struct process {


### PR DESCRIPTION
Updates permissions structs to contain one fs_allowances list each
Copies linked lists (by new allocation) from capability to permissions struct
Copies linked lists (by new allocation) from permissions struct to another list in process struct (this ensures that in place security checks are used, jira issue to be created)
Frees fs_allowances when a permissions_capability struct is free'd.
