### PR TITLE
Remove size limitation of user processes

### DIFF
--- a/src/syscall_handler_process.c
+++ b/src/syscall_handler_process.c
@@ -10,6 +10,8 @@ See the file LICENSE for details.
 #include "memorylayout.h" // PROCESS_ENTRY_POINT
 #include "permissions_capabilities.h"
 
+#define PROCESS_COPY_CHUNK 3500
+
 int32_t sys_exit(uint32_t code) {
     process_exit((int32_t)code);
     return 0;
@@ -41,22 +43,6 @@ int32_t sys_run(const char *process_path, const uint32_t permissions_identifier,
         return -1;
     }
 
-    uint8_t *process_data = kmalloc(proc_file->data_length);
-    if (process_data == 0) {
-        // free the intermediary memory we used
-        kfree(process_data);
-        console_printf("Error loading binary data\n");
-        return -1;
-    }
-
-    int num_read = iso_fread(process_data, proc_file->data_length, 1, proc_file);
-    if (num_read == 0) {
-        // free the intermediary memory we used
-        kfree(process_data);
-        console_printf("Error reading binary data\n");
-        return -1;
-    }
-
     // store the current number of pages used, so we can see how many the child uses
     int page_count_before_child = parent->number_of_pages_using;
 
@@ -65,7 +51,6 @@ int32_t sys_run(const char *process_path, const uint32_t permissions_identifier,
 
     if (child_proc <= 0) {
         // free the intermediary memory we used
-        kfree(process_data);
         process_cleanup(child_proc);
         console_printf("Error creating process\n");
         return -1;
@@ -81,7 +66,6 @@ int32_t sys_run(const char *process_path, const uint32_t permissions_identifier,
     if (!pagetable_getmap(child_proc->pagetable, PROCESS_ENTRY_POINT, &real_addr)) {
         console_printf("Unable to get physical address of 0x80000000\n");
         // free the intermediary memory we used
-        kfree(process_data);
         process_cleanup(child_proc);
         return -1;
     }
@@ -99,7 +83,6 @@ int32_t sys_run(const char *process_path, const uint32_t permissions_identifier,
     // check if we've exceeded the parent's allocation
     if (parent->number_of_pages_using > parent->permissions->max_number_of_pages) {
         console_printf("Error: process %d attempted to create a process %d without available memory: %d > %d\n", parent->pid, child_proc->pid, parent->number_of_pages_using, parent->permissions->max_number_of_pages);
-        kfree(process_data);
         process_cleanup(child_proc);
         return -1;
     }
@@ -107,18 +90,44 @@ int32_t sys_run(const char *process_path, const uint32_t permissions_identifier,
     // check if we've exceeded the child's allocation
     if (child_proc->number_of_pages_using > child_proc->permissions->max_number_of_pages) {
         console_printf("Error: child process %d exceeded its limit\n", child_proc->pid);
-        kfree(process_data);
         process_cleanup(child_proc);
         return -1;
     }
 
-    // Push the new process onto the ready list
-    add_process_to_ready_queue(child_proc);
+    // get and copy the data, chunks at a time
+    uint8_t *process_data = kmalloc(PROCESS_COPY_CHUNK); // intermediary space
+    if (process_data == 0) {
+        // free the intermediary memory we used
+        kfree(process_data);
+        console_printf("Error allocating intermediary space\n");
+        return -1;
+    }
 
-    // Copy data
-    memcpy((void *)real_addr, (void *)process_data, proc_file->data_length);
+    int amount_copied = 0; // amount copied so far
+    uint32_t copy_location = real_addr; // travels with amount copies
+
+    // while there is data to copy
+    while (amount_copied < proc_file->data_length) {
+        int amount_left = proc_file->data_length - amount_copied; // compute amount left
+        int to_be_copied = amount_left < PROCESS_COPY_CHUNK ? amount_left : PROCESS_COPY_CHUNK; // get either chunk or the rest
+
+        int num_read = iso_fread(process_data, to_be_copied, 1, proc_file); // read the chunk
+        if (num_read == 0) {
+            // free the intermediary memory we used
+            kfree(process_data);
+            console_printf("Error reading binary data\n");
+            return -1;
+        }
+        memcpy((void *)copy_location, (void *)process_data, to_be_copied); // copy it to process entry point
+        amount_copied += to_be_copied;
+        copy_location += to_be_copied;
+    }
+
     // free the intermediary memory we used
     kfree(process_data);
+
+    // Push the new process onto the ready list
+    add_process_to_ready_queue(child_proc);
 
     // yield the current process to the new one
     process_yield();


### PR DESCRIPTION
This reworks run()'s use of kmalloc such that the size limit of kmalloc is no longer also the upper limit of the size of user processes. Now, run() copies the process data in chunks, as opposed to all at once.
