### PR TITLE
Fix guru bug, add crossplatform build support

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -22,42 +22,45 @@ LIB_INCLUDE_PATH = ./include
 KERNEL_CCFLAGS = -Wall -c -ffreestanding -m32 -march=i386
 KERNEL_LDFLAGS = -m elf_i386
 
+LD?=ld
+CC?=gcc
+ISOGEN?=genisoimage
+
 all: nunya.iso files.iso
 
 debug: KERNEL_CCFLAGS += -DNUNYA_KDEBUG
 debug: nunya.iso
 
 nunya.iso: nunya.img
-	genisoimage -J -R -o nunya.iso -b nunya.img nunya.img
+	${ISOGEN} -J -R -o nunya.iso -b nunya.img nunya.img
 	rm nunya.img
 
 nunya.img: bootblock kernel
-	cat bootblock kernel > nunya.img
-	truncate nunya.img --size 1474560
+	cat bootblock kernel /dev/zero | head -c 1474560 > nunya.img
 
 bootblock: bootblock.o
-	ld ${KERNEL_LDFLAGS} -Ttext 0 -s --oformat binary $< -o $@
+	${LD} ${KERNEL_LDFLAGS} -Ttext 0 -s --oformat binary $< -o $@
 
 kernel: ${OBJECTS}
-	ld ${KERNEL_LDFLAGS} -Ttext 0x10000 -s --oformat binary ${OBJECTS} -o $@
+	${LD} ${KERNEL_LDFLAGS} -Ttext 0x10000 -s --oformat binary ${OBJECTS} -o $@
 
 %.o: %.c
-	gcc ${KERNEL_CCFLAGS} -I ${LIB_INCLUDE_PATH} $< -o $@
+	${CC} ${KERNEL_CCFLAGS} -I ${LIB_INCLUDE_PATH} $< -o $@
 
 %.o: %.S
-	gcc ${KERNEL_CCFLAGS} $< -o $@
+	${CC} ${KERNEL_CCFLAGS} $< -o $@
 
 %.s: %.c
-	gcc -Wall -S -ffreestanding -m32 -march=i386 -I ${LIB_INCLUDE_PATH} $< -o $@
+	${CC} -Wall -S -ffreestanding -m32 -march=i386 -I ${LIB_INCLUDE_PATH} $< -o $@
 
 files.iso: ${BINARIES}
-	mv -f $^ ../files/bin/ && genisoimage -o ../files.iso ../files/
+	mv -f $^ ../files/bin/ && ${ISOGEN} -o ../files.iso ../files/
 
 bin/%.nun: bin/%.o
-	ld ${KERNEL_LDFLAGS} -Ttext 0x80000000 -s --oformat binary $< syscall.o -o $@
+	${LD} ${KERNEL_LDFLAGS} -Ttext 0x80000000 -s --oformat binary $< syscall.o -o $@
 
 bin/%.o: bin/%.c
-	gcc ${KERNEL_CCFLAGS} -I ${LIB_INCLUDE_PATH} $< -o $@
+	${CC} ${KERNEL_CCFLAGS} -I ${LIB_INCLUDE_PATH} $< -o $@
 
 clean:
 	rm -rf nunya.iso nunya.img bootblock kernel *.o ../files.iso *.nun

--- a/src/mouse.c
+++ b/src/mouse.c
@@ -12,6 +12,7 @@
 #include "graphics.h"
 #include "console.h"
 #include "window_manager.h"
+#include "memory_raw.h"
 
 static uint8_t mouse_cycle = 0;
 static uint8_t mouse_byte[3];
@@ -136,6 +137,10 @@ void mouse_interrupt() {
 }
 
 void mouse_init() {
+    // We need to claim two pages, but we can only claim one at a time from emmory.
+    // Since this is in startup, we can call two in a row and know that it will be contiguous
+    mouse_draw_buffer = memory_alloc_page(1);
+    memory_alloc_page(1);
     // enable port 2 and interrupts for port 2 (enable IRQ12)
     outb(0xA8, PS2_COMMAND_REGISTER);
     uint8_t cont_config_byte = ps2_read_controller_config_byte();

--- a/src/mouse.h
+++ b/src/mouse.h
@@ -24,7 +24,8 @@ int mouse_inited;
 // TODO: to support hotplugging, then every so often, need to query if mouse is alive (send 0xEB and recv and ack)
 extern struct graphics_color mouse_fg_color;
 // mouse is a 30 px by 30 px drawing by default. -1 is for OBOE
-struct graphics_color mouse_draw_buffer[(MOUSE_SIDE - 1) * (MOUSE_SIDE - 1)];
+// struct graphics_color mouse_draw_buffer[(MOUSE_SIDE - 1) * (MOUSE_SIDE - 1)];
+struct graphics_color *mouse_draw_buffer;
 
 /**
  * @brief See if mouse interrupt handling is enabled


### PR DESCRIPTION
The guru bug was caused by a large static allocation in the mouse draw buffer. This caused kernel space to extend into the interrupt table and corrupt it, causing triple faults. To fix this (for now) we alloce space for this during mouse_init. This buffer size (30x30x8) is too large to be allocated with kmalloc, which does not allow for allocations across pages currently. So we use the direct memory_alloc_page instead. We call this method twice in order to reserve two adjacent pages. The adjacency of the allocations is not guranteed, but can be implied from the early level in which this code happens. Once we can allocate memory larger than a page safely, we should revisit this issue

    Also add the ability to build nunya on multiple filesystems by abstracting away commands used for building. You can override $CC, $LD, and $ISOGEN to define your own paths to the tools needed to build. Default values have been provided to ensure backwards compatability with older setups.