### PR TITLE
Fix command line memory corruption

### DIFF
--- a/src/cmd_line.c
+++ b/src/cmd_line.c
@@ -33,7 +33,11 @@ void cmd_line_attempt(const char *line) {
     strip_backspace(line_copy); // Get rid of backspace characters
 
     char *first_word = strtok(line_copy, " ");
-    const char *the_rest_mixed_case = line_copy + (strlen(first_word) + 1);
+    const char *the_rest_mixed_case = 0;
+    if (strlen(first_word) != strlen(line)) {
+        // We need to grab the rest
+        the_rest_mixed_case = line + (strlen(first_word) + 1)*sizeof(char);
+    }
     char the_rest[strlen(the_rest_mixed_case) + 1];
     to_upper(the_rest, the_rest_mixed_case);
 


### PR DESCRIPTION
Our previous handling of string tokenizing in the command line resulted in potentially corrupted memory being read as the second parameter to commands. This fixes that by checking to ensure that there is a second part of the string after tokenization, and otherwise specifically uses a null string

You can check this by running ls in succession before this change, where sometimes it will succeed and sometimes it will attempt to read a garbage file name.